### PR TITLE
Parameter Server - Removes the `shard_size` field from the `Store`s

### DIFF
--- a/comms/src/specs/server.rs
+++ b/comms/src/specs/server.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use serde::{Deserialize, Serialize};
 
 use super::machine_learning::OptimizerSpec;
@@ -57,8 +55,8 @@ pub enum SynchronizerSpec {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StoreSpec {
-    Blocking { shard_size: NonZeroUsize },
-    Wild { shard_size: NonZeroUsize },
+    Blocking,
+    Wild,
 }
 
 /// The specification for the `Server` trait.

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -240,8 +240,8 @@ impl Adapter {
     /// The store's specification or an io error if occurred.
     fn adapt_store(&self, store: &StoreConfig) -> StoreSpec {
         match *store {
-            StoreConfig::Blocking { shard_size } => StoreSpec::Blocking { shard_size },
-            StoreConfig::Wild { shard_size } => StoreSpec::Wild { shard_size },
+            StoreConfig::Blocking => StoreSpec::Blocking,
+            StoreConfig::Wild => StoreSpec::Wild,
         }
     }
 

--- a/orchestrator/src/configs/training.rs
+++ b/orchestrator/src/configs/training.rs
@@ -37,8 +37,8 @@ pub enum SynchronizerConfig {
 /// The `Store` configuration.
 #[derive(Debug, Clone, Copy)]
 pub enum StoreConfig {
-    Blocking { shard_size: NonZeroUsize },
-    Wild { shard_size: NonZeroUsize },
+    Blocking,
+    Wild,
 }
 
 /// The `Algorithm` configuration.

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -23,9 +23,7 @@ fn main() {
         algorithm: AlgorithmConfig::ParameterServer {
             server_addrs: vec!["server-0:40000", "server-1:40001"],
             synchronizer: SynchronizerConfig::Barrier { barrier_size: 1 },
-            store: StoreConfig::Blocking {
-                shard_size: NonZeroUsize::new(2).unwrap(),
-            },
+            store: StoreConfig::Blocking,
         },
         dataset: DatasetConfig::Inline {
             data: vec![

--- a/parameter_server/src/initialization/chained.rs
+++ b/parameter_server/src/initialization/chained.rs
@@ -26,6 +26,13 @@ impl ChainedParamGen {
 }
 
 impl ParamGen for ChainedParamGen {
+    fn size(&self) -> usize {
+        self.param_gens
+            .iter()
+            .map(|param_gen| param_gen.size())
+            .sum()
+    }
+
     fn sample(&mut self, n: usize) -> Option<Vec<f32>> {
         if self.curr == self.param_gens.len() {
             return None;

--- a/parameter_server/src/initialization/constant.rs
+++ b/parameter_server/src/initialization/constant.rs
@@ -24,6 +24,10 @@ impl ConstParamGen {
 }
 
 impl ParamGen for ConstParamGen {
+    fn size(&self) -> usize {
+        self.remaining
+    }
+
     fn sample(&mut self, mut n: usize) -> Option<Vec<f32>> {
         if self.remaining == 0 {
             return None;

--- a/parameter_server/src/initialization/param_gen.rs
+++ b/parameter_server/src/initialization/param_gen.rs
@@ -1,5 +1,11 @@
 /// A `ParamGen` generates values for the initial state of the model's parameters.
 pub trait ParamGen {
+    /// Returns the amount of remaining numbers to be generated.
+    ///
+    /// # Returns
+    /// The amount of numbers left to generate.
+    fn size(&self) -> usize;
+
     /// Should sample at most `n` parameters.
     ///
     /// # Arguments

--- a/parameter_server/src/initialization/random.rs
+++ b/parameter_server/src/initialization/random.rs
@@ -161,6 +161,10 @@ impl<R: Rng> RandParamGen<R, Normal<f32>> {
 }
 
 impl<R: Rng, D: Distribution<f32>> ParamGen for RandParamGen<R, D> {
+    fn size(&self) -> usize {
+        self.remaining
+    }
+
     fn sample(&mut self, mut n: usize) -> Option<Vec<f32>> {
         if self.remaining == 0 {
             return None;

--- a/parameter_server/src/service/builder.rs
+++ b/parameter_server/src/service/builder.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, num::NonZeroUsize, rc::Rc, thread};
 
 use comms::specs::{
     machine_learning::OptimizerSpec,
@@ -14,6 +14,12 @@ use crate::{
     storage::{BlockingStore, Store, StoreHandle, WildStore},
     synchronization::{BarrierSync, NoBlockingSync, Synchronizer},
 };
+
+/// The amount of cores to use if `std::thread::available_parallelism` fails.
+const DEFAULT_CORE_COUNT: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+/// The factor to multiply the amount of cores to obtain the shard amount.
+const SHARD_AMOUNT_FACTOR: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
 /// Makes `callback`'s return type generic, when trying to resolve a concrete `RandParamGen` it avoids boxing all
 /// parameter generators variants.
@@ -286,12 +292,19 @@ impl ServerBuilder {
         OF: FnMut(usize) -> O,
         S: Synchronizer + Send + Sync + 'static,
     {
+        // SAFETY: The argument is at least 1.
+        let nparams = unsafe { NonZeroUsize::new_unchecked(param_gen.size().max(1)) };
+        let cores = thread::available_parallelism().unwrap_or(DEFAULT_CORE_COUNT);
+        let max_shard_amount = cores.saturating_mul(SHARD_AMOUNT_FACTOR);
+        let shard_amount = nparams.min(max_shard_amount);
+        let shard_size = shard_amount.div_ceil(nparams);
+
         match spec.store {
-            StoreSpec::Blocking { shard_size } => {
+            StoreSpec::Blocking => {
                 let store = BlockingStore::new(shard_size, param_gen, optimizer_factory);
                 self.terminate_build(store, synchronizer)
             }
-            StoreSpec::Wild { shard_size } => {
+            StoreSpec::Wild => {
                 let store = WildStore::new(shard_size, param_gen, optimizer_factory);
                 self.terminate_build(store, synchronizer)
             }


### PR DESCRIPTION
Now the `shard_size` is calculated taking the amount of cores in the server.