### PR TITLE
ML - Decouple `Sequential` from `ParamManager`

### DIFF
--- a/machine_learning/src/arch/sequential.rs
+++ b/machine_learning/src/arch/sequential.rs
@@ -1,7 +1,11 @@
-use ndarray::{ArrayView2, ArrayViewD, ArrayViewMutD};
+use ndarray::{ArrayView, ArrayView2, ArrayViewD, ArrayViewMutD, Dimension};
 
 use super::{layers::Layer, loss::LossFn};
-use crate::{MlErr, Result, optimization::Optimizer, param_manager::ParamManager};
+use crate::{
+    MlErr, Result,
+    optimization::Optimizer,
+    param_provider::{BackwardParamIter, ForwardParamIter, ParamProvider},
+};
 
 /// A trainable model, this model's architecture is a sequence of trainable layers.
 #[derive(Clone)]
@@ -40,12 +44,17 @@ impl Sequential {
     ///
     /// # Returns
     /// The prediction for the given input or an error if occurred.
-    pub fn forward<'x, 'mw>(
+    pub fn forward<'x, P, I: Dimension, O: Dimension>(
         &'x mut self,
-        param_manager: &mut ParamManager<'mw>,
-        mut x: ArrayViewD<'x, f32>,
-    ) -> Result<ArrayViewD<'x, f32>> {
-        let mut front = param_manager.front();
+        param_provider: &mut P,
+        x: ArrayView<'x, f32, I>,
+    ) -> Result<ArrayView<'x, f32, O>>
+    where
+        P: ParamProvider,
+    {
+        let mut x = x.into_dyn();
+
+        let mut front = param_provider.front();
         let n = self.layers.len();
 
         for (i, layer) in self.layers.iter_mut().enumerate() {
@@ -57,6 +66,12 @@ impl Sequential {
 
             x = layer.forward(params, x)?;
         }
+
+        let x = x.into_dimensionality().map_err(|_| MlErr::DimMismatch {
+            // TODO: no sé qué poner en got/expected, cambiaría el err
+            got: 0,
+            expected: 0,
+        })?;
 
         Ok(x)
     }
@@ -72,12 +87,15 @@ impl Sequential {
     ///
     /// # Returns
     /// An error if occurred.
-    pub fn backward<'d, 'mw>(
+    pub fn backward<'d, P>(
         &'d mut self,
-        param_manager: &mut ParamManager<'mw>,
+        param_provider: &mut P,
         mut d: ArrayViewMutD<'d, f32>,
-    ) -> Result<()> {
-        let mut back = param_manager.back();
+    ) -> Result<()>
+    where
+        P: ParamProvider,
+    {
+        let mut back = param_provider.back();
         let n = self.layers.len();
 
         for (i, layer) in self.layers.iter_mut().rev().enumerate() {
@@ -115,9 +133,9 @@ impl Sequential {
     ///
     /// # Returns
     /// The epoch loss or an error if the model failed to run a backpropagation epoch.
-    pub fn backprop<'a, 'mw, O, L, I>(
+    pub fn backprop<'a, 'mw, O, L, I, P>(
         &mut self,
-        param_manager: &mut ParamManager<'mw>,
+        param_provider: &mut P,
         optimizers: &mut [O],
         loss_fn: &mut L,
         batches: I,
@@ -126,22 +144,23 @@ impl Sequential {
         L: LossFn,
         O: Optimizer + Send,
         I: Iterator<Item = (ArrayView2<'a, f32>, ArrayView2<'a, f32>)>,
+        P: ParamProvider,
     {
         let mut total_loss = 0.0;
         let mut num_batches = 0;
 
         for (x, y) in batches {
-            let y_pred = self.forward(param_manager, x.into_dyn())?;
+            let y_pred = self.forward(param_provider, x.into_dyn())?;
             let (loss, mut d) = loss_fn.loss_prime(y_pred, y.into_dyn());
 
             total_loss += loss;
             num_batches += 1;
 
-            self.backward(param_manager, d.view_mut())?;
+            self.backward(param_provider, d.view_mut())?;
 
-            param_manager.optimize(optimizers)?;
-            param_manager.acc_grad();
-            param_manager.zero_grad();
+            param_provider.optimize(optimizers)?;
+            param_provider.acc_grad();
+            param_provider.zero_grad();
         }
 
         Ok(total_loss / num_batches as f32)

--- a/machine_learning/src/lib.rs
+++ b/machine_learning/src/lib.rs
@@ -3,6 +3,7 @@ pub mod dataset;
 pub mod error;
 pub mod optimization;
 pub mod param_manager;
+pub mod param_provider;
 mod test;
 pub mod training;
 

--- a/machine_learning/src/param_manager.rs
+++ b/machine_learning/src/param_manager.rs
@@ -1,6 +1,10 @@
 use rayon::prelude::*;
 
-use crate::{MlErr, Result, optimization::Optimizer};
+use crate::{
+    MlErr, Result,
+    optimization::Optimizer,
+    param_provider::{BackwardParamIter, ForwardParamIter, ParamProvider},
+};
 
 /// The state necessary to make forward and backward passes through the network.
 pub struct ServerParamsMetadata<'mw> {
@@ -53,6 +57,18 @@ impl<'mw> ParamManager<'mw> {
             servers,
         }
     }
+}
+
+impl<'mw> ParamProvider for ParamManager<'mw> {
+    type Front<'pm>
+        = FrontIter<'pm, 'mw>
+    where
+        Self: 'pm;
+
+    type Back<'pm>
+        = BackIter<'pm, 'mw>
+    where
+        Self: 'pm;
 
     /// Creates a new `FrontIter` parameter iterator.
     ///
@@ -60,7 +76,7 @@ impl<'mw> ParamManager<'mw> {
     ///
     /// # Returns
     /// A new `FrontIter` instance.
-    pub fn front<'pm>(&'pm mut self) -> FrontIter<'pm, 'mw> {
+    fn front<'pm>(&'pm mut self) -> FrontIter<'pm, 'mw> {
         self.cursors.fill(0);
 
         FrontIter {
@@ -77,7 +93,7 @@ impl<'mw> ParamManager<'mw> {
     ///
     /// # Returns
     /// A new `Backiter` instance.
-    pub fn back<'pm>(&'pm mut self) -> BackIter<'pm, 'mw> {
+    fn back<'pm>(&'pm mut self) -> BackIter<'pm, 'mw> {
         self.cursors.fill(0);
 
         BackIter {
@@ -92,7 +108,7 @@ impl<'mw> ParamManager<'mw> {
     ///
     /// # Arguments
     /// * `optimizers` - A list of optimizers, one per server.
-    pub fn optimize<O: Optimizer + Send>(&mut self, optimizers: &mut [O]) -> Result<()> {
+    fn optimize<O: Optimizer + Send>(&mut self, optimizers: &mut [O]) -> Result<()> {
         if optimizers.len() != self.servers.len() {
             return Err(MlErr::SizeMismatch {
                 what: "optimizers",
@@ -112,14 +128,14 @@ impl<'mw> ParamManager<'mw> {
     }
 
     /// Zeroes out the gradients of every server.
-    pub fn zero_grad(&mut self) {
+    fn zero_grad(&mut self) {
         self.servers
             .par_iter_mut()
             .for_each(|server| server.grad.fill(0.0));
     }
 
     /// Accumulates the current gradient onto the inner accumulated gradients buffer.
-    pub fn acc_grad(&mut self) {
+    fn acc_grad(&mut self) {
         self.servers.par_iter_mut().for_each(|server| {
             for (acc, g) in server.acc_grad_buf.iter_mut().zip(server.grad.iter()) {
                 *acc += *g;
@@ -138,7 +154,7 @@ pub struct FrontIter<'pm, 'mw> {
     curr: usize,
 }
 
-impl FrontIter<'_, '_> {
+impl ForwardParamIter for FrontIter<'_, '_> {
     /// Tries to yield the next layer's parameters and gradient.
     ///
     /// If the requested size is `0`, then the iterator will yield two empty
@@ -151,7 +167,7 @@ impl FrontIter<'_, '_> {
     ///
     /// # Returns
     /// An option denoting if there still are more parameters and gradients.
-    pub fn next(&mut self, n: usize) -> Option<&mut [f32]> {
+    fn next(&mut self, n: usize) -> Option<&mut [f32]> {
         if n == 0 {
             return Some(&mut []);
         }
@@ -182,7 +198,7 @@ pub struct BackIter<'pm, 'mw> {
     curr: usize,
 }
 
-impl BackIter<'_, '_> {
+impl BackwardParamIter for BackIter<'_, '_> {
     /// Tries to yield the next layer's parameters and gradient.
     ///
     /// If the requested size is `0`, then the iterator will yield two empty
@@ -195,7 +211,7 @@ impl BackIter<'_, '_> {
     ///
     /// # Returns
     /// An option denoting if there still are more parameters and gradients.
-    pub fn next(&mut self, n: usize) -> Option<(&mut [f32], &mut [f32])> {
+    fn next(&mut self, n: usize) -> Option<(&mut [f32], &mut [f32])> {
         if n == 0 {
             return Some((&mut [], &mut []));
         }

--- a/machine_learning/src/param_provider.rs
+++ b/machine_learning/src/param_provider.rs
@@ -1,0 +1,26 @@
+use crate::{Result, optimization::Optimizer};
+
+pub trait ForwardParamIter {
+    fn next(&mut self, n: usize) -> Option<&mut [f32]>;
+}
+
+pub trait BackwardParamIter {
+    fn next(&mut self, n: usize) -> Option<(&mut [f32], &mut [f32])>;
+}
+
+pub trait ParamProvider {
+    type Front<'pm>: ForwardParamIter + 'pm
+    where
+        Self: 'pm;
+
+    type Back<'pm>: BackwardParamIter + 'pm
+    where
+        Self: 'pm;
+
+    fn front(&mut self) -> Self::Front<'_>;
+    fn back(&mut self) -> Self::Back<'_>;
+
+    fn optimize<O: Optimizer + Send>(&mut self, optimizers: &mut [O]) -> Result<()>;
+    fn zero_grad(&mut self);
+    fn acc_grad(&mut self);
+}

--- a/machine_learning/src/training/backprop_trainer.rs
+++ b/machine_learning/src/training/backprop_trainer.rs
@@ -8,7 +8,7 @@ use crate::{
     arch::{Sequential, loss::LossFn},
     dataset::Dataset,
     optimization::Optimizer,
-    param_manager::ParamManager,
+    param_provider::ParamProvider,
 };
 
 /// A model `Trainer`. Contains the relevant components needed for training a model,
@@ -79,11 +79,12 @@ where
     }
 }
 
-impl<O, L, R> Trainer for BackpropTrainer<O, L, R>
+impl<O, L, R, P> Trainer<P> for BackpropTrainer<O, L, R>
 where
     O: Optimizer + Send,
     L: LossFn,
     R: Rng,
+    P: ParamProvider,
 {
     /// Performs a training cycle.
     ///
@@ -92,7 +93,7 @@ where
     ///
     /// # Returns
     /// A tuple with the param grads and the epoch loss.
-    fn train<'mw>(&mut self, param_manager: &mut ParamManager<'mw>) -> Result<TrainResult<'_>> {
+    fn train(&mut self, param_provider: &mut P) -> Result<TrainResult<'_>> {
         let remaining = self.max_epochs.get() - self.epoch;
         let epochs = remaining.min(self.offline_epochs + 1);
 
@@ -103,7 +104,7 @@ where
             let batches = self.dataset.batches(self.batch_size);
 
             let loss = self.model.backprop(
-                param_manager,
+                param_provider,
                 &mut self.optimizers,
                 &mut self.loss_fn,
                 batches,

--- a/machine_learning/src/training/builder.rs
+++ b/machine_learning/src/training/builder.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     dataset::Dataset,
     optimization::{GradientDescent, Optimizer},
+    param_manager::ParamManager,
 };
 
 /// Builds `Trainer`s given a specification.
@@ -32,7 +33,11 @@ impl TrainerBuilder {
     ///
     /// # Returns
     /// A new `Trainer`.
-    pub fn build(&self, spec: TrainerSpec, server_sizes: &[usize]) -> Box<dyn Trainer> {
+    pub fn build(
+        &self,
+        spec: TrainerSpec,
+        server_sizes: &[usize],
+    ) -> Box<dyn for<'a> Trainer<ParamManager<'a>>> {
         self.resolve_optimizers(spec, server_sizes)
     }
 
@@ -44,7 +49,11 @@ impl TrainerBuilder {
     ///
     /// # Returns
     /// A new `Trainer`.
-    fn resolve_optimizers(&self, spec: TrainerSpec, server_sizes: &[usize]) -> Box<dyn Trainer> {
+    fn resolve_optimizers(
+        &self,
+        spec: TrainerSpec,
+        server_sizes: &[usize],
+    ) -> Box<dyn for<'a> Trainer<ParamManager<'a>>> {
         match spec.optimizer {
             OptimizerSpec::GradientDescent { learning_rate } => {
                 let optimizers: Vec<_> = server_sizes
@@ -65,7 +74,11 @@ impl TrainerBuilder {
     ///
     /// # Returns
     /// A new `Trainer`.
-    fn resolve_layers<O>(&self, spec: TrainerSpec, optimizers: Vec<O>) -> Box<dyn Trainer>
+    fn resolve_layers<O>(
+        &self,
+        spec: TrainerSpec,
+        optimizers: Vec<O>,
+    ) -> Box<dyn for<'a> Trainer<ParamManager<'a>>>
     where
         O: Optimizer + Send + 'static,
     {
@@ -128,7 +141,7 @@ impl TrainerBuilder {
         spec: TrainerSpec,
         optimizers: Vec<O>,
         layers: Vec<Layer>,
-    ) -> Box<dyn Trainer>
+    ) -> Box<dyn for<'a> Trainer<ParamManager<'a>>>
     where
         O: Optimizer + Send + 'static,
     {
@@ -156,7 +169,7 @@ impl TrainerBuilder {
         optimizers: Vec<O>,
         layers: Vec<Layer>,
         loss_fn: L,
-    ) -> Box<dyn Trainer>
+    ) -> Box<dyn for<'a> Trainer<ParamManager<'a>>>
     where
         O: Optimizer + Send + 'static,
         L: LossFn + 'static,

--- a/machine_learning/src/training/trainer.rs
+++ b/machine_learning/src/training/trainer.rs
@@ -1,4 +1,4 @@
-use crate::{Result, param_manager::ParamManager};
+use crate::{Result, param_provider::ParamProvider};
 
 /// The result of a training call.
 ///
@@ -9,7 +9,7 @@ pub struct TrainResult<'trainer> {
 }
 
 /// This trait generalizes all the different concrete `ModelTrainer` variations between optimizers, loss functions, ...
-pub trait Trainer {
+pub trait Trainer<P: ParamProvider> {
     /// Performs a single training 'cycle'.
     ///
     /// This cycle could involve one or more epochs.
@@ -19,5 +19,5 @@ pub trait Trainer {
     ///
     /// # Returns
     /// A training result declaring if the trianing has finished or should continue.
-    fn train(&mut self, param_manager: &mut ParamManager<'_>) -> Result<TrainResult<'_>>;
+    fn train(&mut self, param_manager: &mut P) -> Result<TrainResult<'_>>;
 }

--- a/worker/src/builder.rs
+++ b/worker/src/builder.rs
@@ -1,7 +1,7 @@
 use comms::specs::worker::WorkerSpec;
 
 use super::worker::Worker;
-use machine_learning::training::TrainerBuilder;
+use machine_learning::{param_provider::ParamProvider, training::TrainerBuilder};
 
 #[derive(Default)]
 pub struct WorkerBuilder;
@@ -22,7 +22,8 @@ impl WorkerBuilder {
     ///
     /// # Returns
     /// A fully initialized `Worker` instance.
-    pub fn build(&self, spec: WorkerSpec, server_sizes: &[usize]) -> Worker {
+    pub fn build(&self, spec: WorkerSpec, server_sizes: &[usize]) -> Worker
+where {
         let trainer_builder = TrainerBuilder::new();
         let trainer = trainer_builder.build(spec.trainer, server_sizes);
         Worker::new(trainer)

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -5,14 +5,17 @@ use comms::{
     msg::{Command, Msg},
 };
 use log::{debug, info, warn};
-use machine_learning::training::{TrainResult, Trainer};
+use machine_learning::{
+    param_manager::ParamManager,
+    training::{TrainResult, Trainer},
+};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::middleware::Middleware;
 
 /// The middleman between the parameter server and the model trainer.
 pub struct Worker {
-    trainer: Box<dyn Trainer>,
+    trainer: Box<dyn for<'a> Trainer<ParamManager<'a>>>,
 }
 
 impl Worker {
@@ -23,7 +26,7 @@ impl Worker {
     ///
     /// # Returns
     /// A new `Worker` instance.
-    pub fn new(trainer: Box<dyn Trainer>) -> Self {
+    pub fn new(trainer: Box<dyn for<'a> Trainer<ParamManager<'a>>>) -> Self {
         Self { trainer }
     }
 


### PR DESCRIPTION
lo arranqué a hacer porque quería testear las capas de ml con lo de conv a pelo y me pareció q estaría copado tener implementaciones más triviales del param manager, en particular, el que tenemos ahora podría ser ono param manager o algo por el estilo, no sé.
La parte del worker (o sea enganchar con el `P` generic) no la podía resolver y el chat me tiró que usara `for<'a>` que sinceramente no lo había visto nunca pero leí [esta](https://doc.rust-lang.org/reference/trait-bounds.html#grammar-ForLifetimes) doc y entendí que lo q hace es sacarse un lifetime de la manga que no está boundeado por nada xd, así que creo que está ok o entendí mal.

Junto con la idea de querer hacer más ergonómico el mod de ml intenté hacer que los arrays que le pasamos a sequential se resuelvan estáticamente (ahora tenemos q son dyn porque tenemos layers conv que escupen 4 dimensiones). Me crashea :(, pero bueno lo tengo que ver.

era para probar más q nada, esta pr puede quedar colgada