### PR TITLE
Early stopping graceful drain

### DIFF
--- a/notebooks/mnist/mnist_test.ipynb
+++ b/notebooks/mnist/mnist_test.ipynb
@@ -140,30 +140,7 @@
    "execution_count": null,
    "id": "5711acec",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[sudo] contraseña para lminervino18: "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#1 [internal] load local bake definitions\n",
-      "#1 reading from stdin 2.18kB done\n",
-      "#1 DONE 0.0s\n",
-      "\n",
-      "#2 [worker-1 internal] load build definition from Dockerfile\n",
-      "#2 transferring dockerfile: 1.10kB done\n",
-      "#2 DONE 0.0s\n",
-      "\n",
-      "#3 [worker-2 internal] load metadata for docker.io/library/rust:1.92\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import getpass\n",
     "\n",
@@ -458,6 +435,7 @@
     "subprocess.run(\n",
     "    [\"docker\", \"compose\", \"-f\", COMPOSE_FILE, \"down\"],\n",
     "    check=True,\n",
+    "\n",
     ")\n",
     "print(\"Done.\")"
    ]

--- a/orchestrator/src/session.rs
+++ b/orchestrator/src/session.rs
@@ -301,9 +301,21 @@ impl Session {
         mut rx_stopper: Receiver<()>,
         tx: Sender<TrainingEvent>,
     ) {
+        let mut stopping = false;
         loop {
             tokio::select! {
-                _ = rx_stopper.recv() => break,
+                _ = rx_stopper.recv(), if !stopping => {
+                    stopping = true;
+                    if let Err(e) = worker_handle.stop().await {
+                        error!("worker {id}: failed to send stop command: {e}");
+                        let event = TrainingEvent::Error(OrchErr::WorkerError {
+                            worker_id: id,
+                            event: format!("failed to send stop command: {e}"),
+                        });
+                        let _ = tx.send(event).await;
+                        return;
+                    }
+                }
                 event = worker_handle.recv_event() => match event {
                     Ok(WorkerEvent::Loss(losses)) => {
                         debug!("worker {id} reported {} losses", losses.len());


### PR DESCRIPTION
Problema: cuando se disparaba el early stopping, worker_listener hacía break  sin avisar al worker remoto. El worker seguía corriendo y mandaba gradientes al parameter server, que esperaba en el BarrierSync a todos los workers. Como uno nunca llegaba, deadlock.  Solución: antes de entrar en drain mode, worker_listener ahora envía  StopAfterEpoch al worker remoto. El worker termina su epoch actual, se desconecta limpiamente, y la barrera se satisface sin deadlock.  