### PR TITLE
Conv for mismatched input dimensions

### DIFF
--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -1,3 +1,5 @@
+use std::cmp;
+
 use ndarray::prelude::*;
 use ndarray_conv::{ConvExt, ConvMode, PaddingMode, ReverseKernel};
 
@@ -19,6 +21,7 @@ pub struct Conv2d {
     size: usize,
 
     // Forward metadata
+    real_input_dim: (usize, usize),
     effective_input: Array4<f32>,
     output: Array4<f32>,
 
@@ -38,6 +41,7 @@ impl Conv2d {
         let kernels_size = filters * in_channels * kernel_size * kernel_size;
         let kernels_dim = (filters, in_channels, kernel_size, kernel_size);
         let size = kernels_size + filters;
+        let real_input_dim = (0, 0);
 
         let zeros4 = Array4::zeros((1, 1, 1, 1));
 
@@ -50,6 +54,7 @@ impl Conv2d {
             kernels_size,
             kernels_dim,
             size,
+            real_input_dim,
             effective_input: zeros4.clone(),
             output: zeros4.clone(),
             delta_out: zeros4.clone(),
@@ -69,6 +74,7 @@ impl Conv2d {
             kernel_size,
             stride,
             padding,
+            ref mut real_input_dim,
             ref mut effective_input,
             ref mut output,
             ..
@@ -76,35 +82,28 @@ impl Conv2d {
 
         let (batch_size, _, input_height, input_width) = x.dim();
 
+        *real_input_dim = (input_height, input_width);
+
         let output_height = (input_height + 2 * padding - kernel_size) / stride + 1;
         let output_width = (input_width + 2 * padding - kernel_size) / stride + 1;
+
         let effective_height = (output_height - 1) * stride + kernel_size;
         let effective_width = (output_width - 1) * stride + kernel_size;
-        println!("effective_height: {effective_height}");
-        println!("effective_width: {effective_width}");
-        // let output_height = (effective_height + 2 * padding - kernel_size) / stride + 1;
-        // let output_width = (effective_width + 2 * padding - kernel_size) / stride + 1;
 
         effective_input.reshape_inplace((x.dim().0, x.dim().1, effective_height, effective_width));
         effective_input.fill(0.);
-        println!("effective_input:\n{:#}", effective_input);
+
+        // dropped elements could just be padding
+        let copy_height = cmp::min(input_height, effective_height - padding);
+        let copy_width = cmp::min(input_width, effective_width - padding);
 
         let mut effective_input_view = effective_input.slice_mut(s![
             ..,
             ..,
-            padding..effective_height,
-            padding..effective_width
+            padding..padding + copy_height,
+            padding..padding + copy_width,
         ]);
-        println!("effective_input_view:\n{:#}", effective_input_view);
-
-        let input_view = &x.slice(s![
-            ..,
-            ..,
-            ..effective_height - padding,
-            ..effective_width - padding
-        ]);
-        println!("input_view:\n{:#}", input_view);
-
+        let input_view = &x.slice(s![.., .., ..copy_height, ..copy_width]);
         effective_input_view.assign(input_view);
 
         output.reshape_inplace((batch_size, filters, output_height, output_width));
@@ -130,7 +129,6 @@ impl Conv2d {
 
         *output += &b;
 
-        println!("conv2d forward done");
         Ok(output.view())
     }
 
@@ -148,8 +146,8 @@ impl Conv2d {
         let Self {
             filters,
             in_channels,
-            kernel_size,
             padding,
+            real_input_dim,
             ref effective_input,
             ref mut delta_out,
             ref mut dilated,
@@ -158,8 +156,14 @@ impl Conv2d {
 
         let batch_size = effective_input.dim().0;
 
-        // delta_out.reshape_inplace(effective_input.dim());
-        // delta_out.fill(0.);
+        dk.fill(0.);
+        delta_out.reshape_inplace((
+            effective_input.dim().0,
+            effective_input.dim().1,
+            real_input_dim.0,
+            real_input_dim.1,
+        ));
+        delta_out.fill(0.);
 
         for b_idx in 0..batch_size {
             for f_idx in 0..filters {
@@ -167,43 +171,37 @@ impl Conv2d {
 
                 for c_idx in 0..in_channels {
                     // kernel
-                    let input_bc = effective_input.slice(s![b_idx, c_idx, .., ..]);
+                    let effective_input_bc = effective_input.slice(s![b_idx, c_idx, .., ..]);
 
-                    println!("input_bc:\n{:#?}", input_bc);
-                    println!("dilated_bf:\n{:#?}", dilated_bf);
-                    let step = input_bc
-                        .conv(
-                            dilated_bf.no_reverse(),
-                            // ConvMode::Custom {
-                            //     padding: [padding; 2],
-                            //     strides: [1; 2],
-                            // },
-                            ConvMode::Valid,
-                            PaddingMode::Zeros,
-                        )
+                    let dk_step = effective_input_bc
+                        .conv(dilated_bf.no_reverse(), ConvMode::Valid, PaddingMode::Zeros)
                         .unwrap();
-                    println!("step:\n{:#?}", step);
 
                     let mut dk_view = dk.slice_mut(s![f_idx, c_idx, .., ..]);
-                    println!("dk_view:\n{:#?}", dk_view);
-                    dk_view += &step;
+                    dk_view += &dk_step;
 
                     // delta
                     let k_fc = k.slice(s![f_idx, c_idx, .., ..]);
 
-                    let step = dilated_bf
-                        .conv(
-                            &k_fc,
-                            ConvMode::Custom {
-                                padding: [kernel_size - padding - 1; 2],
-                                strides: [1; 2],
-                            },
-                            PaddingMode::Zeros,
-                        )
+                    let effective_delta_step = dilated_bf
+                        .conv(&k_fc, ConvMode::Full, PaddingMode::Zeros)
                         .unwrap();
+                    let delta_step = effective_delta_step.slice(s![
+                        padding
+                            ..padding
+                                + cmp::min(real_input_dim.0, effective_input.dim().2 - padding),
+                        padding
+                            ..padding
+                                + cmp::min(real_input_dim.1, effective_input.dim().3 - padding),
+                    ]);
 
-                    let mut delta_view = delta_out.slice_mut(s![b_idx, c_idx, .., ..]);
-                    delta_view += &step;
+                    let mut delta_view = delta_out.slice_mut(s![
+                        b_idx,
+                        c_idx,
+                        ..cmp::min(real_input_dim.0, effective_input.dim().2 - padding),
+                        ..cmp::min(real_input_dim.1, effective_input.dim().3 - padding)
+                    ]);
+                    delta_view += &delta_step;
                 }
             }
         }
@@ -211,7 +209,6 @@ impl Conv2d {
         let db_sum = d_in.sum_axis(Axis(0)).sum_axis(Axis(1)).sum_axis(Axis(1));
         db.assign(&db_sum);
 
-        println!("conv2d backward done");
         Ok(delta_out.view_mut())
     }
 
@@ -432,7 +429,7 @@ mod tests {
     ) {
         let mut conv = Conv2d::new(filters, in_channels, kernel_size, stride, padding);
         let output = conv.forward(params, input.view()).unwrap();
-        println!("output:\n{:#}", output);
+        // println!("output:\n{:#}", output);
         assert_eq!(output, expected);
     }
 
@@ -609,7 +606,7 @@ mod tests {
         let delta_out = conv
             .backward(params, &mut grad, delta_in.view_mut())
             .unwrap();
-        println!("delta_out:\n{:#}", delta_out);
+        // println!("delta_out:\n{:#}", delta_out);
         assert_eq!(delta_out, expected_delta_out);
         // println!("grad:\n{:#?}", grad);
         assert_eq!(grad, expected_grad);
@@ -715,14 +712,14 @@ mod tests {
         let input_width = 8;
         let kernel_size = 3;
         let params = vec![0.; kernel_size * kernel_size + 1];
-        let input = Array4::from_elem((1, 1, input_height, input_width), 1.);
+        let input = Array4::from_elem((1, 1, input_height, input_width), 0.);
         // the dimensionality of the upstream delta is the same that as the output
         let output_height = 4;
         let output_width = 4;
-        let mut delta_in = Array4::from_elem((1, 1, output_height, output_width), 1.);
+        let mut delta_in = Array4::from_elem((1, 1, output_height, output_width), 0.);
         let mut conv = Conv2d::new(1, 1, kernel_size, 2, 1);
 
-        let expected_delta_out = Array4::from_elem((1, 1, input_height, input_width), 1.);
+        let expected_delta_out = Array4::from_elem((1, 1, input_height, input_width), 0.);
         let expected_grad = vec![0.; kernel_size * kernel_size + 1];
 
         test_conv2d_backward(

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -22,6 +22,7 @@ pub struct Conv2d {
 
     // Forward metadata
     real_input_dim: (usize, usize),
+    /// The input that's actually used during the forward convolution
     effective_input: Array4<f32>,
     output: Array4<f32>,
 
@@ -173,9 +174,11 @@ impl Conv2d {
                     // kernel
                     let effective_input_bc = effective_input.slice(s![b_idx, c_idx, .., ..]);
 
-                    let dk_step = effective_input_bc
-                        .conv(dilated_bf.no_reverse(), ConvMode::Valid, PaddingMode::Zeros)
-                        .unwrap();
+                    let dk_step = effective_input_bc.conv(
+                        dilated_bf.no_reverse(),
+                        ConvMode::Valid,
+                        PaddingMode::Zeros,
+                    )?;
 
                     let mut dk_view = dk.slice_mut(s![f_idx, c_idx, .., ..]);
                     dk_view += &dk_step;
@@ -183,24 +186,18 @@ impl Conv2d {
                     // delta
                     let k_fc = k.slice(s![f_idx, c_idx, .., ..]);
 
-                    let effective_delta_step = dilated_bf
-                        .conv(&k_fc, ConvMode::Full, PaddingMode::Zeros)
-                        .unwrap();
+                    let copy_height = cmp::min(real_input_dim.0, effective_input.dim().2 - padding);
+                    let copy_width = cmp::min(real_input_dim.1, effective_input.dim().3 - padding);
+
+                    let effective_delta_step =
+                        dilated_bf.conv(&k_fc, ConvMode::Full, PaddingMode::Zeros)?;
                     let delta_step = effective_delta_step.slice(s![
-                        padding
-                            ..padding
-                                + cmp::min(real_input_dim.0, effective_input.dim().2 - padding),
-                        padding
-                            ..padding
-                                + cmp::min(real_input_dim.1, effective_input.dim().3 - padding),
+                        padding..padding + copy_height,
+                        padding..padding + copy_width
                     ]);
 
-                    let mut delta_view = delta_out.slice_mut(s![
-                        b_idx,
-                        c_idx,
-                        ..cmp::min(real_input_dim.0, effective_input.dim().2 - padding),
-                        ..cmp::min(real_input_dim.1, effective_input.dim().3 - padding)
-                    ]);
+                    let mut delta_view =
+                        delta_out.slice_mut(s![b_idx, c_idx, ..copy_height, ..copy_width]);
                     delta_view += &delta_step;
                 }
             }
@@ -238,9 +235,8 @@ impl Conv2d {
 
         dilated.reshape_inplace(dilated_dim);
         // NOTE: this might not be needed as the assigned delta overwrites the past one if
-        // dimensions match. I leave it commented out as it's pretty expensive to fill up the whole
-        // dilated tensor with zeros.
-        // dilated.fill(0.);
+        // dimensions match.
+        dilated.fill(0.);
         dilated
             .slice_mut(s![.., ..,
                 ..dilated_height; stride,
@@ -298,9 +294,8 @@ impl Conv2d {
     ) -> Result<(ArrayViewMut4<'a, f32>, ArrayViewMut1<'a, f32>)> {
         let Self {
             filters,
-            in_channels,
-            kernel_size,
             kernels_size,
+            kernels_dim,
             size,
             ..
         } = *self;
@@ -317,7 +312,6 @@ impl Conv2d {
         //         gradient is exactly the size of the layer.
         let (dw_raw, db_raw) = grad.split_at_mut(kernels_size);
 
-        let kernels_dim = (filters, in_channels, kernel_size, kernel_size);
         let dw = ArrayViewMut4::from_shape(kernels_dim, dw_raw).unwrap();
         let db = ArrayViewMut1::from_shape(filters, db_raw).unwrap();
 

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -132,6 +132,9 @@ impl Conv2d {
         let batch_size = input.dim().0;
 
         delta_out.reshape_inplace(input.dim());
+        // TODO: delta was accumulating garbage in each itearation, zero every buffer that is being
+        // accumulated!!!!
+        delta_out.fill(0.);
 
         for b_idx in 0..batch_size {
             for f_idx in 0..filters {

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -132,8 +132,6 @@ impl Conv2d {
         let batch_size = input.dim().0;
 
         delta_out.reshape_inplace(input.dim());
-        // TODO: delta was accumulating garbage in each itearation, zero every buffer that is being
-        // accumulated!!!!
         delta_out.fill(0.);
 
         for b_idx in 0..batch_size {
@@ -205,6 +203,10 @@ impl Conv2d {
         );
 
         dilated.reshape_inplace(dilated_dim);
+        // NOTE: this might not be needed as the assigned delta overwrites the past one if
+        // dimensions match. I leave it commented out as it's pretty expensive to fill up the whole
+        // dilated tensor with zeros.
+        // dilated.fill(0.);
         dilated
             .slice_mut(s![.., ..,
                 ..dilated_height; stride,
@@ -555,20 +557,14 @@ mod tests {
         test_conv2d_forward(2, 2, 2, 1, 1, &params, &input, &expected);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn test_conv2d_backward(
-        filters: usize,
-        in_channels: usize,
-        kernel_size: usize,
-        stride: usize,
-        padding: usize,
+        conv: &mut Conv2d,
         params: &[f32],
         input: &Array4<f32>,
         delta_in: &mut Array4<f32>,
         expected_delta_out: &Array4<f32>,
         expected_grad: &[f32],
     ) {
-        let mut conv = Conv2d::new(filters, in_channels, kernel_size, stride, padding);
         let mut grad = vec![0.; params.len()];
         let _ = conv.forward(params, input.view()).unwrap();
         let delta_out = conv
@@ -580,6 +576,7 @@ mod tests {
 
     #[test]
     fn test_conv2d08_backward_filters1_in_channels1_kernel_size2_stride2_padding0() {
+        let mut conv = Conv2d::new(1, 1, 2, 2, 0);
         let params: [f32; 5] = [1., 2., 3., 4., 5.];
         let input: Array4<f32> = array![[[
             [1., 2., 3., 4.],
@@ -596,11 +593,43 @@ mod tests {
         ]]];
         let expected_grad = [462., 536., 758., 832., 74.];
         test_conv2d_backward(
-            1,
-            1,
-            2,
-            2,
-            0,
+            &mut conv,
+            &params,
+            &input,
+            &mut delta_in,
+            &expected_delta_out,
+            &expected_grad,
+        );
+    }
+
+    #[test]
+    fn test_conv2d09_backward_should_return_same_output_if_ran_twice() {
+        let mut conv = Conv2d::new(1, 1, 2, 2, 0);
+        let params: [f32; 5] = [1., 2., 3., 4., 5.];
+        let input: Array4<f32> = array![[[
+            [1., 2., 3., 4.],
+            [5., 6., 7., 8.],
+            [9., 10., 11., 12.],
+            [13., 14., 15., 16.]
+        ]]];
+        let mut delta_in: Array4<f32> = array![[[[17., 18.], [19., 20.]]]];
+        let expected_delta_out = array![[[
+            [17., 34., 18., 36.],
+            [51., 68., 54., 72.],
+            [19., 38., 20., 40.],
+            [57., 76., 60., 80.]
+        ]]];
+        let expected_grad = [462., 536., 758., 832., 74.];
+        test_conv2d_backward(
+            &mut conv,
+            &params,
+            &input,
+            &mut delta_in,
+            &expected_delta_out,
+            &expected_grad,
+        );
+        test_conv2d_backward(
+            &mut conv,
             &params,
             &input,
             &mut delta_in,

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -104,6 +104,7 @@ impl Conv2d {
 
         *output += &b;
 
+        println!("conv2d forward done");
         Ok(output.view())
     }
 
@@ -122,6 +123,7 @@ impl Conv2d {
             filters,
             in_channels,
             kernel_size,
+            stride,
             padding,
             ref input,
             ref mut delta_out,
@@ -134,37 +136,52 @@ impl Conv2d {
         delta_out.reshape_inplace(input.dim());
         delta_out.fill(0.);
 
+        let output_height = (self.input.dim().2 + 2 * padding - kernel_size) / stride + 1;
+        let output_width = (self.input.dim().3 + 2 * padding - kernel_size) / stride + 1;
+        let effective_height = (output_height - 1) * stride + kernel_size - padding * 2;
+        let effective_width = (output_width - 1) * stride + kernel_size - padding * 2;
+
         for b_idx in 0..batch_size {
             for f_idx in 0..filters {
                 let dilated_bf = dilated.slice(s![b_idx, f_idx, .., ..]);
 
                 for c_idx in 0..in_channels {
                     // kernel
-                    let input_bc = input.slice(s![b_idx, c_idx, .., ..]);
+                    let input_bc =
+                        input.slice(s![b_idx, c_idx, ..effective_height, ..effective_width]);
+                    // input.slice(s![b_idx, c_idx, ..8, ..8]);
 
-                    let step = input_bc.conv(
-                        dilated_bf.no_reverse(),
-                        ConvMode::Custom {
-                            padding: [padding; 2],
-                            strides: [1; 2],
-                        },
-                        PaddingMode::Zeros,
-                    )?;
+                    println!("input_bc:\n{:#?}", input_bc);
+                    println!("dilated_bf:\n{:#?}", dilated_bf);
+                    let step = input_bc
+                        .conv(
+                            dilated_bf.no_reverse(),
+                            ConvMode::Custom {
+                                padding: [padding; 2],
+                                strides: [1; 2],
+                            },
+                            PaddingMode::Zeros,
+                        )
+                        .unwrap();
+                    println!("step:\n{:#?}", step);
 
                     let mut dk_view = dk.slice_mut(s![f_idx, c_idx, .., ..]);
+                    println!("dk_view:\n{:#?}", dk_view);
                     dk_view += &step;
 
                     // delta
                     let k_fc = k.slice(s![f_idx, c_idx, .., ..]);
 
-                    let step = dilated_bf.conv(
-                        &k_fc,
-                        ConvMode::Custom {
-                            padding: [kernel_size - padding - 1; 2],
-                            strides: [1; 2],
-                        },
-                        PaddingMode::Zeros,
-                    )?;
+                    let step = dilated_bf
+                        .conv(
+                            &k_fc,
+                            ConvMode::Custom {
+                                padding: [kernel_size - padding - 1; 2],
+                                strides: [1; 2],
+                            },
+                            PaddingMode::Zeros,
+                        )
+                        .unwrap();
 
                     let mut delta_view = delta_out.slice_mut(s![b_idx, c_idx, .., ..]);
                     delta_view += &step;
@@ -175,6 +192,7 @@ impl Conv2d {
         let db_sum = d_in.sum_axis(Axis(0)).sum_axis(Axis(1)).sum_axis(Axis(1));
         db.assign(&db_sum);
 
+        println!("conv2d backward done");
         Ok(delta_out.view_mut())
     }
 
@@ -570,7 +588,9 @@ mod tests {
         let delta_out = conv
             .backward(params, &mut grad, delta_in.view_mut())
             .unwrap();
+        println!("delta_out:\n{:#}", delta_out);
         assert_eq!(delta_out, expected_delta_out);
+        // println!("grad:\n{:#?}", grad);
         assert_eq!(grad, expected_grad);
     }
 
@@ -628,6 +648,60 @@ mod tests {
             &expected_delta_out,
             &expected_grad,
         );
+        test_conv2d_backward(
+            &mut conv,
+            &params,
+            &input,
+            &mut delta_in,
+            &expected_delta_out,
+            &expected_grad,
+        );
+    }
+
+    // The forward convolution will drop values that don't fit.
+    // In this example:
+    // * input (w/ padding): 10x10
+    // * filter: 3x3
+    // With a stride of 2, the filter fits 4 times before there is one element missing in the
+    // width dimension. We could add more padding or just drop the element.
+    #[test]
+    fn test_conv2d10_forward_with_input_kernel_convolution_mismatch() {
+        let input_height = 8;
+        let input_width = 8;
+        let kernel_size = 3;
+        let params = vec![0.; kernel_size * kernel_size + 1];
+        let input = Array4::from_elem((1, 1, input_height, input_width), 0.);
+        let expected = Array4::from_elem((1, 1, 4, 4), 0.);
+        test_conv2d_forward(1, 1, kernel_size, 2, 1, &params, &input, &expected);
+    }
+
+    // So, what happens with the backward pass convolution?
+    // Well, first the convolution between the input and the dilated upstream delta should match
+    // the dimensionality of the kernel gradient, which is just the dimensionality of the kernel.
+    // In this example that's 3x3.
+    // The problem is that the actual convolution between the 10x10 padded input and the dilated
+    // upstream 7x7 delta outputs a 4x4 matrix (without having into account the extra higher
+    // dimensions).
+    // The solution is to compute the convolution a *effective* input and the dilated upstread
+    // delta. With effective input I mean the input that was actually used for the convolution in
+    // the forward pass, so that means dropping the right-most elements that the kernel did not
+    // touch there.
+    #[test]
+    fn test_conv2d11_forward_with_input_kernel_convolution_mismatch() {
+        let input_height = 8;
+        let input_width = 8;
+        let kernel_size = 3;
+        let params = vec![0.; kernel_size * kernel_size + 1];
+        let input = Array4::from_elem((1, 1, input_height, input_width), 0.);
+        // the dimensionality of the upstream delta is the same that as the output
+        let output_height = 4;
+        let output_width = 4;
+        let mut delta_in = Array4::from_elem((1, 1, output_height, output_width), 0.);
+        let mut conv = Conv2d::new(1, 1, kernel_size, 2, 1);
+
+        let expected_delta_out = Array4::from_elem((1, 1, input_height, input_width), 0.);
+        let expected_grad = vec![0.; kernel_size * kernel_size + 1];
+
         test_conv2d_backward(
             &mut conv,
             &params,

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -19,7 +19,7 @@ pub struct Conv2d {
     size: usize,
 
     // Forward metadata
-    input: Array4<f32>,
+    effective_input: Array4<f32>,
     output: Array4<f32>,
 
     // Backward metadata
@@ -50,7 +50,7 @@ impl Conv2d {
             kernels_size,
             kernels_dim,
             size,
-            input: zeros4.clone(),
+            effective_input: zeros4.clone(),
             output: zeros4.clone(),
             delta_out: zeros4.clone(),
             dilated: zeros4,
@@ -69,29 +69,55 @@ impl Conv2d {
             kernel_size,
             stride,
             padding,
-            ref mut input,
+            ref mut effective_input,
             ref mut output,
             ..
         } = *self;
-
-        input.reshape_inplace(x.raw_dim());
-        input.assign(&x);
 
         let (batch_size, _, input_height, input_width) = x.dim();
 
         let output_height = (input_height + 2 * padding - kernel_size) / stride + 1;
         let output_width = (input_width + 2 * padding - kernel_size) / stride + 1;
+        let effective_height = (output_height - 1) * stride + kernel_size;
+        let effective_width = (output_width - 1) * stride + kernel_size;
+        println!("effective_height: {effective_height}");
+        println!("effective_width: {effective_width}");
+        // let output_height = (effective_height + 2 * padding - kernel_size) / stride + 1;
+        // let output_width = (effective_width + 2 * padding - kernel_size) / stride + 1;
+
+        effective_input.reshape_inplace((x.dim().0, x.dim().1, effective_height, effective_width));
+        effective_input.fill(0.);
+        println!("effective_input:\n{:#}", effective_input);
+
+        let mut effective_input_view = effective_input.slice_mut(s![
+            ..,
+            ..,
+            padding..effective_height,
+            padding..effective_width
+        ]);
+        println!("effective_input_view:\n{:#}", effective_input_view);
+
+        let input_view = &x.slice(s![
+            ..,
+            ..,
+            ..effective_height - padding,
+            ..effective_width - padding
+        ]);
+        println!("input_view:\n{:#}", input_view);
+
+        effective_input_view.assign(input_view);
+
         output.reshape_inplace((batch_size, filters, output_height, output_width));
 
         for b in 0..batch_size {
-            let input_b = x.index_axis(Axis(0), b);
+            let input_b = self.effective_input.index_axis(Axis(0), b);
 
             for f in 0..filters {
                 let kernel_f = k.index_axis(Axis(0), f);
                 let res_3d = input_b.conv(
                     kernel_f.no_reverse(),
                     ConvMode::Custom {
-                        padding: [0, padding, padding],
+                        padding: [0; 3],
                         strides: [1, stride, stride],
                     },
                     PaddingMode::Zeros,
@@ -123,23 +149,17 @@ impl Conv2d {
             filters,
             in_channels,
             kernel_size,
-            stride,
             padding,
-            ref input,
+            ref effective_input,
             ref mut delta_out,
             ref mut dilated,
             ..
         } = *self;
 
-        let batch_size = input.dim().0;
+        let batch_size = effective_input.dim().0;
 
-        delta_out.reshape_inplace(input.dim());
-        delta_out.fill(0.);
-
-        let output_height = (self.input.dim().2 + 2 * padding - kernel_size) / stride + 1;
-        let output_width = (self.input.dim().3 + 2 * padding - kernel_size) / stride + 1;
-        let effective_height = (output_height - 1) * stride + kernel_size - padding * 2;
-        let effective_width = (output_width - 1) * stride + kernel_size - padding * 2;
+        // delta_out.reshape_inplace(effective_input.dim());
+        // delta_out.fill(0.);
 
         for b_idx in 0..batch_size {
             for f_idx in 0..filters {
@@ -147,19 +167,18 @@ impl Conv2d {
 
                 for c_idx in 0..in_channels {
                     // kernel
-                    let input_bc =
-                        input.slice(s![b_idx, c_idx, ..effective_height, ..effective_width]);
-                    // input.slice(s![b_idx, c_idx, ..8, ..8]);
+                    let input_bc = effective_input.slice(s![b_idx, c_idx, .., ..]);
 
                     println!("input_bc:\n{:#?}", input_bc);
                     println!("dilated_bf:\n{:#?}", dilated_bf);
                     let step = input_bc
                         .conv(
                             dilated_bf.no_reverse(),
-                            ConvMode::Custom {
-                                padding: [padding; 2],
-                                strides: [1; 2],
-                            },
+                            // ConvMode::Custom {
+                            //     padding: [padding; 2],
+                            //     strides: [1; 2],
+                            // },
+                            ConvMode::Valid,
                             PaddingMode::Zeros,
                         )
                         .unwrap();
@@ -311,6 +330,8 @@ impl Conv2d {
 
 #[cfg(test)]
 mod tests {
+    use std::env;
+
     use super::*;
 
     #[test]
@@ -687,19 +708,21 @@ mod tests {
     // the forward pass, so that means dropping the right-most elements that the kernel did not
     // touch there.
     #[test]
-    fn test_conv2d11_forward_with_input_kernel_convolution_mismatch() {
+    fn test_conv2d11_backward_with_input_kernel_convolution_mismatch() {
+        unsafe { env::set_var("RUST_BACKTRACE", "1") };
+
         let input_height = 8;
         let input_width = 8;
         let kernel_size = 3;
         let params = vec![0.; kernel_size * kernel_size + 1];
-        let input = Array4::from_elem((1, 1, input_height, input_width), 0.);
+        let input = Array4::from_elem((1, 1, input_height, input_width), 1.);
         // the dimensionality of the upstream delta is the same that as the output
         let output_height = 4;
         let output_width = 4;
-        let mut delta_in = Array4::from_elem((1, 1, output_height, output_width), 0.);
+        let mut delta_in = Array4::from_elem((1, 1, output_height, output_width), 1.);
         let mut conv = Conv2d::new(1, 1, kernel_size, 2, 1);
 
-        let expected_delta_out = Array4::from_elem((1, 1, input_height, input_width), 0.);
+        let expected_delta_out = Array4::from_elem((1, 1, input_height, input_width), 1.);
         let expected_grad = vec![0.; kernel_size * kernel_size + 1];
 
         test_conv2d_backward(

--- a/machine_learning/src/test.rs
+++ b/machine_learning/src/test.rs
@@ -380,7 +380,7 @@ fn test_conv_dense(
     );
 
     let offline_epochs = 0;
-    let max_epochs = NonZeroUsize::new(500).unwrap();
+    let max_epochs = NonZeroUsize::new(1000).unwrap();
     let batch_size = NonZeroUsize::new(4).unwrap();
     let optimizer = GradientDescent::new(1.0);
     let mut loss_fn = Mse::new();
@@ -412,7 +412,7 @@ fn test_conv_dense(
     let y_pred = model.forward(&mut param_manager, x.into_dyn()).unwrap();
 
     let loss = loss_fn.loss(y_pred.view(), y.into_dyn());
-    assert!(loss < 0.01);
+    assert!(loss < 0.001);
     // println!("y:{y:#?}\n\n\ny_pred:{y_pred:#?}");
     // println!("loss: {loss}");
 }
@@ -643,4 +643,74 @@ fn test_machine_learning08_3by3by2_filters1_kernel_size3_stride1_padding1() {
         &labels,
         y_size,
     );
+}
+
+#[test]
+fn test_machine_learning_dimensionality_correctness() {
+    unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+
+    let nsamples = 10;
+
+    let in_channels = 1;
+    let input_height = 28;
+    let input_width = 28;
+
+    let x_size = in_channels * input_height * input_width;
+    let y_size = 10;
+
+    let samples = vec![1.; nsamples * x_size];
+    let labels = vec![1.; nsamples * y_size];
+
+    let filters = 4;
+    let kernel_size = 3;
+    let stride = 2;
+    let padding = 1;
+
+    let output_height = (input_height + 2 * padding - kernel_size) / stride + 1;
+    let output_width = (input_width + 2 * padding - kernel_size) / stride + 1;
+
+    let model = Sequential::new(vec![
+        Layer::two_d_to4d(in_channels, input_height, input_width),
+        Layer::conv2d(filters, in_channels, kernel_size, stride, padding),
+        Layer::four_d_to2d(filters, output_height, output_width),
+        Layer::dense((filters * output_height * output_width, y_size)),
+        Layer::sigmoid(1.0),
+    ]);
+    let nparams = model.size();
+    let nreal_layers = 2;
+    let ordering = vec![0; nreal_layers];
+
+    let dataset = Dataset::new(
+        DatasetSrc::inmem(samples, labels),
+        NonZeroUsize::new(x_size).unwrap(),
+        NonZeroUsize::new(y_size).unwrap(),
+    );
+
+    let offline_epochs = 0;
+    let max_epochs = NonZeroUsize::new(10).unwrap();
+    let batch_size = NonZeroUsize::new(4).unwrap();
+    let optimizer = GradientDescent::new(1.0);
+    let loss_fn = Mse::new();
+    let rng = StdRng::from_os_rng();
+
+    let mut trainer = BackpropTrainer::new(
+        model,
+        vec![optimizer],
+        dataset,
+        loss_fn,
+        offline_epochs,
+        max_epochs,
+        batch_size,
+        rng,
+    );
+
+    let mut params_grads = gen_params_grads(&[nparams]);
+    let servers: Vec<_> = params_grads
+        .iter_mut()
+        .map(|(params, grad, acc_grad_buf)| ServerParamsMetadata::new(params, grad, acc_grad_buf))
+        .collect();
+
+    let mut param_manager = ParamManager::new(servers, &ordering);
+
+    assert!(trainer.train(&mut param_manager).is_ok())
 }


### PR DESCRIPTION
vamos a tomar una convención adentro de conv para evitar rechazar configuraciones de conv que no matchean bien la dimensionalidad de los inputs con la del kernel.
<img width="610" height="899" alt="problema-conv-input-mismatch" src="https://github.com/user-attachments/assets/253fa01b-3d23-4adf-b985-07ed4890f660" />