### PR TITLE
feat: AllReduceWorker early stopping

### DIFF
--- a/node/src/router.rs
+++ b/node/src/router.rs
@@ -1,11 +1,11 @@
 use std::io;
 
 use comms::{
-    Acceptor, Connection, Connector, OrchEvent, OrchHandle, PullSpecResponse, TransportLayer,
+    Acceptor, Connection, Connector, OrchHandle, PullSpecResponse, TransportLayer,
     get_dataset_cursor,
     specs::{server::ServerSpec, worker::WorkerSpec},
 };
-use log::{info, warn};
+use log::{error, info, warn};
 use parameter_server::service::ServerBuilder;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -62,27 +62,12 @@ where
     ///
     /// # Returns
     /// An io error if occurred.
-    async fn run_server(
-        &mut self,
-        mut orch_handle: OrchHandle<T>,
-        spec: ServerSpec,
-    ) -> io::Result<()> {
+    async fn run_server(&mut self, orch_handle: OrchHandle<T>, spec: ServerSpec) -> io::Result<()> {
         info!("starting parameter server session");
 
         let mut server_builder = ServerBuilder::new(&mut self.acceptor);
-        let mut pserver = server_builder.build(spec).await?;
-
-        let mut params = pserver.run().await?;
-        loop {
-            match orch_handle.recv_event().await? {
-                OrchEvent::Disconnect => {
-                    orch_handle.disconnect().await?;
-                    break;
-                }
-                OrchEvent::RequestParams => orch_handle.push_params(&mut params).await?,
-                event => warn!("Unexpected OrchEvent: {event:?}"),
-            }
-        }
+        let mut pserver = server_builder.build(spec, orch_handle).await?;
+        pserver.run().await?;
 
         info!("parameter server session finished");
         Ok(())
@@ -105,30 +90,26 @@ where
     /// Returns an io error if the underlying listener fails.
     pub async fn run(mut self) -> io::Result<()> {
         loop {
-            info!("waiting for next session");
-
+            info!("awaiting connection");
             let conn = self.acceptor.accept().await?;
 
             let Connection::Orchestrator(mut orch_handle) = conn else {
-                warn!(
-                    "expected orchestrator as first connection, got unexpected connection type; skipping"
-                );
+                warn!("expected an orchestrator connection, got something else");
                 continue;
             };
 
-            info!("accepted orchestrator connection");
-
-            let result = match orch_handle.pull_specification().await {
-                Err(e) => Err(e),
-                Ok(PullSpecResponse::ParameterServer(spec)) => {
-                    self.run_server(orch_handle, spec).await
-                }
-                Ok(PullSpecResponse::Worker(spec)) => self.run_worker(orch_handle, spec).await,
+            let Ok(spec) = orch_handle.pull_specification().await else {
+                warn!("failed to get node specification");
+                continue;
             };
 
-            match result {
-                Ok(()) => info!("session finished, waiting for next session"),
-                Err(e) => warn!("session failed: {e}, resetting and waiting for next session"),
+            let result = match spec {
+                PullSpecResponse::ParameterServer(spec) => self.run_server(orch_handle, spec).await,
+                PullSpecResponse::Worker(spec) => self.run_worker(orch_handle, spec).await,
+            };
+
+            if let Err(e) = result {
+                error!("session failed with an error: {e}");
             }
         }
     }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, ExitStatus},
 };
 
-use comms::floats::{Float01, FloatPositive};
+use comms::floats::{Float01, FloatNonNegative, FloatPositive};
 use orchestrator::{CancelHandle, configs::*, train};
 
 const MODEL_OUTPUT_PATH: &str = "model.safetensors";
@@ -61,7 +61,7 @@ fn build_addresses(workers: usize, servers: usize) -> (Vec<String>, Vec<String>)
 
 fn main() -> io::Result<()> {
     const WORKERS: usize = 3;
-    const SERVERS: usize = 0;
+    const SERVERS: usize = 2;
     const RELEASE: bool = false;
 
     setup_docker(WORKERS, SERVERS, RELEASE)?;
@@ -163,7 +163,9 @@ fn main() -> io::Result<()> {
         max_epochs: NonZeroUsize::new(1000).unwrap(),
         offline_epochs: 0,
         seed: Some(42),
-        early_stopping: None,
+        early_stopping: Some(EarlyStoppingConfig {
+            tolerance: FloatNonNegative::new(0.5).unwrap(),
+        }),
     };
 
     let session = train(model_config, training_config).unwrap();

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -61,7 +61,7 @@ fn build_addresses(workers: usize, servers: usize) -> (Vec<String>, Vec<String>)
 
 fn main() -> io::Result<()> {
     const WORKERS: usize = 3;
-    const SERVERS: usize = 2;
+    const SERVERS: usize = 0;
     const RELEASE: bool = false;
 
     setup_docker(WORKERS, SERVERS, RELEASE)?;

--- a/orchestrator/src/session.rs
+++ b/orchestrator/src/session.rs
@@ -157,7 +157,7 @@ pub enum StopReason {
 }
 
 /// A handle that lets any caller request an early stop of an ongoing training session.
-pub struct CancelHandle(mpsc::Sender<()>);
+pub struct CancelHandle(Sender<()>);
 
 impl CancelHandle {
     /// Creates a matched `(CancelHandle, Receiver)` pair.
@@ -165,7 +165,7 @@ impl CancelHandle {
     /// The caller retains the `CancelHandle` and passes the `Receiver` to
     /// `Session::event_listener`. Calling `stop()` on the handle signals
     /// the session to stop at the next epoch boundary.
-    pub fn pair() -> (Self, mpsc::Receiver<()>) {
+    pub fn pair() -> (Self, Receiver<()>) {
         let (tx, rx) = mpsc::channel(1);
         (Self(tx), rx)
     }
@@ -196,6 +196,7 @@ pub enum TrainingEvent {
 #[derive(Debug)]
 enum WorkerHandleRequest {
     PullParams,
+    Disconnect,
     Stop,
 }
 
@@ -306,16 +307,18 @@ impl Session {
     async fn worker_listener(
         id: usize,
         mut worker_handle: WorkerHandle<NetRtp>,
-        mut rx_stopper: Receiver<WorkerHandleRequest>,
+        mut wk_rx: Receiver<WorkerHandleRequest>,
         tx: Sender<TrainingEvent>,
     ) {
         let mut stopping = false;
         loop {
             tokio::select! {
-                req = rx_stopper.recv() => {
+                req = wk_rx.recv() => {
                     match req {
-                        Some(WorkerHandleRequest::Stop) if !stopping => {
+                        Some(WorkerHandleRequest::Stop) if stopping => {}
+                        Some(WorkerHandleRequest::Stop) => {
                             stopping = true;
+
                             if let Err(e) = worker_handle.stop().await {
                                 error!("worker {id}: failed to send stop command: {e}");
 
@@ -334,11 +337,11 @@ impl Session {
                                     let _ = tx.send(TrainingEvent::Params(params.to_vec())).await;
                                 },
                                 Err(e) => {
-                                    error!("worker {id}: failed to pull params command: {e}");
+                                    error!("worker {id}: failed to send pull params command: {e}");
 
                                     let event = TrainingEvent::Error(OrchErr::WorkerError {
                                         worker_id: id,
-                                        event: format!("failed to pull params command: {e}"),
+                                        event: format!("failed to send pull params command: {e}"),
                                     });
 
                                     let _ = tx.send(event).await;
@@ -346,7 +349,20 @@ impl Session {
                                 },
                             }
                         }
-                        _ => {}
+                        Some(WorkerHandleRequest::Disconnect) => {
+                            if let Err(e) = worker_handle.disconnect().await {
+                                error!("worker {id}: failed to send disconnect command: {e}");
+
+                                let event = TrainingEvent::Error(OrchErr::WorkerError {
+                                    worker_id: id,
+                                    event: format!("failed to send disconnect command: {e}"),
+                                });
+
+                                let _ = tx.send(event).await;
+                            }
+                            return;
+                        }
+                        None => {}
                     }
                 },
                 event = worker_handle.recv_event() => match event {
@@ -408,7 +424,7 @@ impl Session {
     ///
     /// # Returns
     /// A receiver that yields `TrainingEvent`s as training progresses.
-    pub fn event_listener(self, mut cancel_rx: mpsc::Receiver<()>) -> Receiver<TrainingEvent> {
+    pub fn event_listener(self, mut cancel_rx: Receiver<()>) -> Receiver<TrainingEvent> {
         let (event_tx, event_rx) = mpsc::channel(256);
 
         let model = self.model;
@@ -441,15 +457,7 @@ impl Session {
                         Self::finalize_parameter_server(self.servers, &event_tx).await
                     }
                     AlgorithmSpec::AllReduce { .. } => {
-                        let mut i = 0;
-                        loop {
-                            let _ = wk_txs[i].send(WorkerHandleRequest::PullParams).await;
-                            if let Some(TrainingEvent::Params(params)) = internal_rx.recv().await {
-                                break params.to_vec();
-                            }
-
-                            i = (i + 1) % wk_txs.len();
-                        }
+                        Self::finalize_all_reduce(&mut wk_txs, &mut internal_rx).await
                     }
                 };
 
@@ -495,9 +503,9 @@ impl Session {
     }
 
     async fn run_training_loop(
-        cancel_rx: &mut mpsc::Receiver<()>,
-        internal_rx: &mut mpsc::Receiver<TrainingEvent>,
-        wk_txs: &mut Vec<Sender<WorkerHandleRequest>>,
+        cancel_rx: &mut Receiver<()>,
+        internal_rx: &mut Receiver<TrainingEvent>,
+        wk_txs: &mut [Sender<WorkerHandleRequest>],
         n_workers: usize,
         early_stopping: &Option<EarlyStoppingConfig>,
         event_tx: &Sender<TrainingEvent>,
@@ -555,7 +563,9 @@ impl Session {
                             let _ = event_tx.send(TrainingEvent::Error(e)).await;
                             return None;
                         }
-                        other => { let _ = event_tx.send(other).await; }
+                        other => {
+                            let _ = event_tx.send(other).await;
+                        }
                     }
                 }
             }
@@ -588,6 +598,29 @@ impl Session {
         }
 
         model_params
+    }
+
+    async fn finalize_all_reduce(
+        wk_txs: &mut Vec<Sender<WorkerHandleRequest>>,
+        internal_rx: &mut Receiver<TrainingEvent>,
+    ) -> Vec<f32> {
+        let mut i = 0;
+
+        let params = loop {
+            let _ = wk_txs[i].send(WorkerHandleRequest::PullParams).await;
+
+            if let Some(TrainingEvent::Params(params)) = internal_rx.recv().await {
+                break params.to_vec();
+            }
+
+            i = (i + 1) % wk_txs.len();
+        };
+
+        for tx in wk_txs {
+            let _ = tx.send(WorkerHandleRequest::Disconnect).await;
+        }
+
+        params
     }
 
     /// Connects to all nodes and bootstraps each as a parameter server.

--- a/orchestui/run.sh
+++ b/orchestui/run.sh
@@ -9,7 +9,8 @@ read NWORKERS NSERVERS < <(python3 -c "
 import json
 
 d = json.load(open('$ORCHESTUI_DIR/training.json'))
-ps = d.get('algorithm', {}).get('parameter_server', {})
+algo = d.get('algorithm', {})
+ps = algo.get('parameter_server', {}) if isinstance(algo, dict) else {}
 
 nworkers = len(d.get('worker_addrs', []))
 nservers = len(ps.get('server_addrs', []))

--- a/parameter_server/src/service/builder.rs
+++ b/parameter_server/src/service/builder.rs
@@ -1,7 +1,7 @@
 use std::{io, num::NonZeroUsize, thread};
 
 use comms::{
-    Acceptor, Connection, TransportLayer,
+    Acceptor, Connection, OrchHandle, TransportLayer,
     specs::{
         machine_learning::OptimizerSpec,
         server::{ServerSpec, StoreSpec, SynchronizerSpec},
@@ -50,13 +50,23 @@ where
     ///
     /// # Args
     /// * `spec` - The specification of the parameter server.
+    /// * `orch_handle` - The handle for communicating with the orchestrator.
     ///
     /// # Returns
     /// A new Server or a `RandErr` if the specification has
     /// invalid `RandParamGen` construction values.
-    pub async fn build(&mut self, spec: ServerSpec) -> io::Result<Box<dyn Server<T>>> {
+    pub async fn build(
+        &mut self,
+        spec: ServerSpec,
+        orch_handle: OrchHandle<T>,
+    ) -> io::Result<Box<dyn Server<T>>>
+    where
+        T: TransportLayer,
+    {
         let nworkers = spec.nworkers;
-        let mut server = self.resolve_optimizer(spec).map_err(io::Error::other)?;
+        let mut server = self
+            .resolve_optimizer(spec, orch_handle)
+            .map_err(io::Error::other)?;
 
         for _ in 0..nworkers {
             let Connection::Worker(worker_handle) = self.acceptor.accept().await? else {
@@ -73,11 +83,15 @@ where
     ///
     /// # Args
     /// * `spec` - The specification for the parameter server.
-    /// * `param_gen` - A resolved parameter generator.
+    /// * `orch_handle` - The handle for communicating with the orchestrator.
     ///
     /// # Returns
     /// A new server.
-    fn resolve_optimizer(&self, spec: ServerSpec) -> Result<Box<dyn Server<T>>> {
+    fn resolve_optimizer(
+        &self,
+        spec: ServerSpec,
+        orch_handle: OrchHandle<T>,
+    ) -> Result<Box<dyn Server<T>>> {
         match spec.optimizer {
             OptimizerSpec::Adam {
                 learning_rate,
@@ -86,18 +100,18 @@ where
                 epsilon,
             } => {
                 let factory = |len| Adam::new(len, learning_rate, beta1, beta2, epsilon);
-                self.resolve_store(spec, factory)
+                self.resolve_store(spec, orch_handle, factory)
             }
             OptimizerSpec::GradientDescent { learning_rate } => {
                 let factory = |_| GradientDescent::new(learning_rate);
-                self.resolve_store(spec, factory)
+                self.resolve_store(spec, orch_handle, factory)
             }
             OptimizerSpec::GradientDescentWithMomentum {
                 learning_rate,
                 momentum,
             } => {
                 let factory = |len| GradientDescentWithMomentum::new(len, learning_rate, momentum);
-                self.resolve_store(spec, factory)
+                self.resolve_store(spec, orch_handle, factory)
             }
         }
     }
@@ -106,15 +120,15 @@ where
     ///
     /// # Args
     /// * `spec` - The specification for the parameter server.
-    /// * `param_gen` - A resolved parameter generator.
+    /// * `orch_handle` - The handle for communicating with the orchestrator.
     /// * `optimizer_factory` - A factory of optimizers.
-    /// * `synchronizer` - A resolved synchronizer.
     ///
     /// # Returns
     /// A new server.
     fn resolve_store<O, OF>(
         &self,
         spec: ServerSpec,
+        orch_handle: OrchHandle<T>,
         optimizer_factory: OF,
     ) -> Result<Box<dyn Server<T>>>
     where
@@ -134,11 +148,11 @@ where
         match spec.store {
             StoreSpec::Blocking => {
                 let store = BlockingStore::new(shard_size, param_gen.as_mut(), optimizer_factory);
-                Ok(self.resolve_synchronizer(spec, store))
+                Ok(self.resolve_synchronizer(spec, orch_handle, store))
             }
             StoreSpec::Wild => {
                 let store = WildStore::new(shard_size, param_gen.as_mut(), optimizer_factory);
-                Ok(self.resolve_synchronizer(spec, store))
+                Ok(self.resolve_synchronizer(spec, orch_handle, store))
             }
         }
     }
@@ -147,23 +161,28 @@ where
     ///
     /// # Args
     /// * `spec` - The specification for the parameter server.
-    /// * `param_gen` - A resolved parameter generator.
-    /// * `optimizer_factory` - A factory of optimizers.
+    /// * `orch_handle` - The handle for communicating with the orchestrator.
+    /// * `store` - A resolved store.
     ///
     /// # Returns
     /// A new server.
-    fn resolve_synchronizer<PS>(&self, spec: ServerSpec, store: PS) -> Box<dyn Server<T>>
+    fn resolve_synchronizer<PS>(
+        &self,
+        spec: ServerSpec,
+        orch_handle: OrchHandle<T>,
+        store: PS,
+    ) -> Box<dyn Server<T>>
     where
         PS: Store + Send + Sync + 'static,
     {
         match spec.synchronizer {
             SynchronizerSpec::Barrier { barrier_size } => {
                 let synchronizer = BarrierSync::new(barrier_size);
-                self.terminate_build(store, synchronizer)
+                self.terminate_build(orch_handle, store, synchronizer)
             }
             SynchronizerSpec::NonBlocking => {
                 let synchronizer = NoBlockingSync::new();
-                self.terminate_build(store, synchronizer)
+                self.terminate_build(orch_handle, store, synchronizer)
             }
         }
     }
@@ -171,18 +190,24 @@ where
     /// Terminates the entire build for this session and finally instanciates all the entities.
     ///
     /// # Args
+    /// * `orch_handle` - The handle for communicating with the orchestrator.
     /// * `store` - A resolved store.
     /// * `synchronizer` - A resolved synchronizer.
     ///
     /// # Returns
     /// A new server.
-    fn terminate_build<PS, Sy>(&self, store: PS, synchronizer: Sy) -> Box<dyn Server<T>>
+    fn terminate_build<PS, Sy>(
+        &self,
+        orch_handle: OrchHandle<T>,
+        store: PS,
+        synchronizer: Sy,
+    ) -> Box<dyn Server<T>>
     where
         PS: Store + Send + Sync + 'static,
         Sy: Synchronizer + Send + Sync + 'static,
     {
         let handle = StoreHandle::new(store);
-        let pserver = ParameterServer::new(handle, synchronizer);
+        let pserver = ParameterServer::new(handle, synchronizer, orch_handle);
         Box::new(pserver)
     }
 }

--- a/parameter_server/src/service/pserver.rs
+++ b/parameter_server/src/service/pserver.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use comms::{TransportLayer, WorkerEvent, WorkerHandle};
+use comms::{OrchEvent, OrchHandle, TransportLayer, WorkerEvent, WorkerHandle};
 use log::{debug, error, info, warn};
 use tokio::task::JoinSet;
 
@@ -11,13 +11,24 @@ use crate::{
 };
 
 /// The central server structure, it handles task management and io between workers.
-pub struct ParameterServer<PS: Store, Sy: Synchronizer> {
+pub struct ParameterServer<PS, Sy, T>
+where
+    PS: Store,
+    Sy: Synchronizer,
+    T: TransportLayer,
+{
     tasks: JoinSet<io::Result<()>>,
     handle: StoreHandle<PS>,
     synchronizer: Sy,
+    orch_handle: OrchHandle<T>,
 }
 
-impl<PS: Store, Sy: Synchronizer> ParameterServer<PS, Sy> {
+impl<PS, Sy, T> ParameterServer<PS, Sy, T>
+where
+    PS: Store,
+    Sy: Synchronizer,
+    T: TransportLayer,
+{
     /// Creates a new `ParameterServer`.
     ///
     /// # Args
@@ -26,21 +37,27 @@ impl<PS: Store, Sy: Synchronizer> ParameterServer<PS, Sy> {
     ///
     /// # Returns
     /// A new `ParameterServer` instance.
-    pub fn new(handle: StoreHandle<PS>, synchronizer: Sy) -> Self {
+    pub fn new(handle: StoreHandle<PS>, synchronizer: Sy, orch_handle: OrchHandle<T>) -> Self {
         Self {
             tasks: JoinSet::new(),
             handle,
             synchronizer,
+            orch_handle,
         }
     }
 }
 
-impl<PS: Store, Sy: Synchronizer> ParameterServer<PS, Sy> {
+impl<PS, Sy, T> ParameterServer<PS, Sy, T>
+where
+    PS: Store,
+    Sy: Synchronizer,
+    T: TransportLayer,
+{
     /// Starts the training process with the spawned workers.
     ///
     /// # Returns
     /// The trained parameters of the model.
-    pub async fn run(&mut self) -> io::Result<Vec<f32>> {
+    pub async fn run(&mut self) -> io::Result<()> {
         while let Some(ret) = self.tasks.join_next().await {
             match ret {
                 Ok(Err(e)) => {
@@ -60,16 +77,30 @@ impl<PS: Store, Sy: Synchronizer> ParameterServer<PS, Sy> {
         let nparams = self.handle.len();
         let mut params = vec![0.; nparams];
         self.handle.pull_params(&mut params).await.unwrap();
-        Ok(params)
+
+        loop {
+            match self.orch_handle.recv_event().await? {
+                OrchEvent::Disconnect => break,
+                OrchEvent::RequestParams => self.orch_handle.push_params(&mut params).await?,
+                event => warn!("Unexpected OrchEvent: {event:?}"),
+            }
+        }
+
+        Ok(())
     }
 }
 
-impl<PS: Store + Send + Sync + 'static, Sy: Synchronizer + 'static> ParameterServer<PS, Sy> {
+impl<PS, Sy, T> ParameterServer<PS, Sy, T>
+where
+    PS: Store + Send + Sync + 'static,
+    Sy: Synchronizer + 'static,
+    T: TransportLayer,
+{
     /// Binds a new worker to this server and spawns it's own training task.
     ///
     /// # Args
     /// * `worker_handle` - The handle for a worker connection.
-    pub fn spawn<T>(&mut self, mut worker_handle: WorkerHandle<T>)
+    pub fn spawn(&mut self, mut worker_handle: WorkerHandle<T>)
     where
         T: TransportLayer + Send + 'static,
     {
@@ -126,13 +157,13 @@ impl<PS: Store + Send + Sync + 'static, Sy: Synchronizer + 'static> ParameterSer
 }
 
 #[async_trait::async_trait]
-impl<T, PS, Sy> Server<T> for ParameterServer<PS, Sy>
+impl<T, PS, Sy> Server<T> for ParameterServer<PS, Sy, T>
 where
-    T: TransportLayer + Send + 'static,
     PS: Store + Send + Sync + 'static,
     Sy: Synchronizer + Send + 'static,
+    T: TransportLayer + Send + 'static,
 {
-    async fn run(&mut self) -> io::Result<Vec<f32>> {
+    async fn run(&mut self) -> io::Result<()> {
         self.run().await
     }
 

--- a/parameter_server/src/service/server.rs
+++ b/parameter_server/src/service/server.rs
@@ -10,7 +10,7 @@ where
     T: TransportLayer,
 {
     /// Indirection method for `ParameterServer::run`.
-    async fn run(&mut self) -> io::Result<Vec<f32>>;
+    async fn run(&mut self) -> io::Result<()>;
 
     /// Indirection method for `ParameterServer::spawn`
     ///

--- a/parameter_server/src/test.rs
+++ b/parameter_server/src/test.rs
@@ -2,7 +2,7 @@
 
 use std::{env, num::NonZeroUsize};
 
-use comms::{ParamServerHandle, WorkerHandle, floats::FloatPositive};
+use comms::{OrchHandle, ParamServerHandle, WorkerEvent, WorkerHandle, floats::FloatPositive};
 use machine_learning::{initialization::ConstParamGen, optimization::GradientDescent};
 use tokio::io::{self, AsyncRead, AsyncWrite, DuplexStream, ReadHalf, WriteHalf};
 
@@ -22,7 +22,14 @@ fn channel_pair() -> (
     (chan1, chan2)
 }
 
-async fn mock_lineal_worker<R, W>(rx: R, tx: W, max_epochs: usize, nparams: usize) -> io::Result<()>
+async fn mock_lineal_worker<R, W>(
+    rx: R,
+    tx: W,
+    orch_rx: R,
+    orch_tx: W,
+    max_epochs: usize,
+    nparams: usize,
+) -> io::Result<()>
 where
     R: AsyncRead + Unpin + Send,
     W: AsyncWrite + Unpin + Send,
@@ -30,6 +37,9 @@ where
     let mut grad = vec![0.0; nparams];
     let transport = comms::build_simple_transport(rx, tx);
     let mut server_handle = ParamServerHandle::new(0, transport);
+
+    let transport = comms::build_simple_transport(orch_rx, orch_tx);
+    let mut orch_handle = OrchHandle::new(transport);
 
     for _ in 0..max_epochs {
         let params = server_handle.pull_params().await?;
@@ -41,7 +51,28 @@ where
     }
 
     server_handle.disconnect().await?;
+    orch_handle.done().await?;
+    orch_handle.disconnect().await?;
     Ok(())
+}
+
+async fn mock_orch<R, W>(wk_rx: R, wk_tx: W, sv_rx: R, sv_tx: W) -> io::Result<Vec<f32>>
+where
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
+{
+    let transport = comms::build_simple_transport(wk_rx, wk_tx);
+    let mut worker_handle = WorkerHandle::new(0, transport);
+
+    let transport = comms::build_simple_transport(sv_rx, sv_tx);
+    let mut server_handle = ParamServerHandle::new(0, transport);
+
+    while !matches!(worker_handle.recv_event().await?, WorkerEvent::Done) {}
+    while !matches!(worker_handle.recv_event().await?, WorkerEvent::Disconnect) {}
+
+    let params = server_handle.pull_params().await?.to_vec();
+    server_handle.disconnect().await?;
+    Ok(params)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -49,6 +80,8 @@ async fn test_lineal_convergence() -> io::Result<()> {
     unsafe { env::set_var("RUST_BACKTRACE", "1") };
 
     let ((wk_rx, wk_tx), (sv_rx, sv_tx)) = channel_pair();
+    let ((sv_orch_rx, sv_orch_tx), (orch_sv_rx, orch_sv_tx)) = channel_pair();
+    let ((wk_orch_rx, wk_orch_tx), (orch_wk_rx, orch_wk_tx)) = channel_pair();
 
     const MAX_EPOCHS: usize = 100;
     const NPARAMS: usize = 2;
@@ -59,14 +92,17 @@ async fn test_lineal_convergence() -> io::Result<()> {
     let store = BlockingStore::new(shard_size, &mut param_gen, optimizer_factory);
     let handle = StoreHandle::new(store);
     let synchronizer = BarrierSync::new(1);
-    let mut server = ParameterServer::new(handle, synchronizer);
+    let transport = comms::build_simple_transport(sv_orch_rx, sv_orch_tx);
+    let orch_handle = OrchHandle::new(transport);
+    let mut server = ParameterServer::new(handle, synchronizer, orch_handle);
 
     let transport = comms::build_simple_transport(sv_rx, sv_tx);
     let worker_handle = WorkerHandle::new(0, transport);
     server.spawn(worker_handle);
 
-    let worker_fut = mock_lineal_worker(wk_rx, wk_tx, MAX_EPOCHS, NPARAMS);
-    let (_, params) = tokio::try_join!(worker_fut, server.run())?;
+    let worker_fut = mock_lineal_worker(wk_rx, wk_tx, wk_orch_rx, wk_orch_tx, MAX_EPOCHS, NPARAMS);
+    let orchestrator_fut = mock_orch(orch_wk_rx, orch_wk_tx, orch_sv_rx, orch_sv_tx);
+    let (_, _, params) = tokio::try_join!(worker_fut, server.run(), orchestrator_fut)?;
     println!("params: {params:?}");
     Ok(())
 }

--- a/worker/src/middlewares/worker_ring.rs
+++ b/worker/src/middlewares/worker_ring.rs
@@ -91,11 +91,7 @@ where
     /// An io error if occurred.
     pub async fn disconnect(&mut self) -> io::Result<()> {
         self.next.disconnect().await?;
-
-        if !matches!(self.prev.recv_event().await?, WorkerEvent::Disconnect) {
-            return Err(io::Error::other("Expected Disconnect from previous worker"));
-        }
-
+        while !matches!(self.prev.recv_event().await?, WorkerEvent::Disconnect) {}
         Ok(())
     }
 

--- a/worker/src/workers/all_reduce.rs
+++ b/worker/src/workers/all_reduce.rs
@@ -66,10 +66,11 @@ where
             should_continue = !was_last;
 
             tokio::select! {
+                biased;
                 event = self.orch_handle.recv_event() => match event? {
                     OrchEvent::Stop => {
                         info!("received a stop command from orchestrator");
-                        should_continue = false;
+                        break;
                     }
                     OrchEvent::Disconnect => {
                         info!("received a disconnect command from the orchestrator");
@@ -93,7 +94,6 @@ where
             }
         }
 
-        self.ring_manager.disconnect().await?;
         self.orch_handle.done().await?;
 
         if let OrchEvent::RequestParams = self.orch_handle.recv_event().await? {
@@ -101,6 +101,7 @@ where
         }
 
         self.orch_handle.disconnect().await?;
+        self.ring_manager.disconnect().await?;
         Ok(())
     }
 }

--- a/worker/src/workers/all_reduce.rs
+++ b/worker/src/workers/all_reduce.rs
@@ -96,12 +96,14 @@ where
 
         self.orch_handle.done().await?;
 
-        if let OrchEvent::RequestParams = self.orch_handle.recv_event().await? {
-            self.orch_handle.push_params(&mut self.params).await?;
+        loop {
+            match self.orch_handle.recv_event().await? {
+                OrchEvent::Disconnect => break,
+                OrchEvent::RequestParams => self.orch_handle.push_params(&mut self.params).await?,
+                other => warn!("unexpected message from orchestrator, got: {other:?}"),
+            }
         }
 
-        self.orch_handle.disconnect().await?;
-        self.ring_manager.disconnect().await?;
-        Ok(())
+        self.ring_manager.disconnect().await
     }
 }


### PR DESCRIPTION
Le implementé el early stopping al worker, intenté cambiar lo menos posible para que ande bien. Sin embargo le metí cambios al `NodeRouter` también porque me llamaba la atención de que para el server haciamos usabamos el `orch_handle` desde afuera del `run` del server, cosa que para los workers no es así, lo cambié para que sea más facil de seguir el código. Aparte aproveché y toquetié los docstrings del `ServerBuilder` que habían quedado mal los argumentos de casi todos.