### PR TITLE
Strategy Switch - Orchestrator frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,16 @@
 [workspace]
-members = ["comms", "parameter_server", "worker", "machine_learning", "orchestrator", "orchestui", "orchestra-py", "node"]
+members = [
+  "comms",
+  "parameter_server",
+  "worker",
+  "machine_learning",
+  "orchestrator",
+  "orchestui",
+  "orchestra-py",
+  "node",
+]
 resolver = "2"
+
+[workspace.lints.clippy]
+type_complexity = "allow"
+too_many_arguments = "allow"

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.48.0", features = ["full"] }
 trait-variant = "0.1.2"
+
+[lints]
+workspace = true

--- a/comms/src/codec/sink.rs
+++ b/comms/src/codec/sink.rs
@@ -6,7 +6,7 @@ use super::{LEN_TYPE_SIZE, LenType};
 use crate::{protocol::Msg, utils};
 
 /// The sending end handle of the communication.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Sink<W: AsyncWrite + Unpin> {
     writer: W,
     buf: Vec<u8>,

--- a/comms/src/codec/source.rs
+++ b/comms/src/codec/source.rs
@@ -6,7 +6,7 @@ use super::{LEN_TYPE_SIZE, LenType};
 use crate::protocol::Msg;
 
 /// The receiving end handle of the communication.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Source<R: AsyncRead + Unpin> {
     reader: R,
     buf: Vec<u32>,

--- a/comms/src/floats/float_non_negative.rs
+++ b/comms/src/floats/float_non_negative.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 #[derive(Serialize, Debug, Clone, Copy)]
 #[serde(transparent)]
 pub struct FloatNonNegative {
-    value: f32,
+    value: f64,
 }
 
 impl FloatNonNegative {
@@ -16,7 +16,7 @@ impl FloatNonNegative {
     ///
     /// # Returns
     /// An option with `Some` value if the given `value` is not negative, else `None`.
-    pub fn new(value: f32) -> Option<Self> {
+    pub fn new(value: f64) -> Option<Self> {
         value
             .is_sign_positive()
             .then_some(FloatNonNegative { value })
@@ -38,14 +38,14 @@ impl<'de> Deserialize<'de> for FloatNonNegative {
     where
         D: Deserializer<'de>,
     {
-        let value = f32::deserialize(deserializer)?;
+        let value = f64::deserialize(deserializer)?;
         FloatNonNegative::new(value)
             .ok_or_else(|| de::Error::custom("FloatNonNegative value must be non negative"))
     }
 }
 
 impl Deref for FloatNonNegative {
-    type Target = f32;
+    type Target = f64;
 
     fn deref(&self) -> &Self::Target {
         &self.value

--- a/comms/src/handles/compressor.rs
+++ b/comms/src/handles/compressor.rs
@@ -11,6 +11,7 @@ pub enum CompressedGrad<'a> {
 
 /// Compresses a given residual gradient into a slice of f16 or a sparse binary
 /// formatted slice.
+#[derive(Debug)]
 pub struct Compressor<R>
 where
     R: Rng,
@@ -20,6 +21,7 @@ where
 }
 
 /// The necessary metadata for enabling sparse gradient compression.
+#[derive(Debug)]
 struct SparseCapability<R>
 where
     R: Rng,

--- a/comms/src/handles/orchestrator.rs
+++ b/comms/src/handles/orchestrator.rs
@@ -4,7 +4,7 @@ use super::DatasetSrc;
 use crate::{
     protocol::{Command, Msg, Payload},
     share_dataset,
-    specs::{node::NodeSpec, server::ServerSpec},
+    specs::{machine_learning::TrainerSpec, node::NodeSpec, server::ServerSpec},
     transport::TransportLayer,
 };
 
@@ -24,6 +24,7 @@ pub enum OrchEvent {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     },
     Upgrade {
         spec: ServerSpec,
@@ -107,10 +108,12 @@ where
                 server_addrs,
                 server_sizes,
                 server_ordering,
+                trainer_spec,
             }) => OrchEvent::Switch {
                 server_addrs,
                 server_sizes,
                 server_ordering,
+                trainer_spec,
             },
             Msg::Control(Command::ShareDataset) => OrchEvent::ShareDataset,
             msg => {

--- a/comms/src/handles/parameter_server.rs
+++ b/comms/src/handles/parameter_server.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// The handle for communicating with a `ParameterServer`.
+#[derive(Debug)]
 pub struct ParamServerHandle<T> {
     id: usize,
     transport: T,

--- a/comms/src/handles/worker.rs
+++ b/comms/src/handles/worker.rs
@@ -189,7 +189,7 @@ impl<T: TransportLayer> WorkerHandle<T> {
     ///
     /// # Args
     /// * `server_addrs` - The network addresses of the servers.
-    /// * `server_sizes` - The sizes in amount of paremters per server.
+    /// * `server_sizes` - The sizes in amount of parameters per server.
     /// * `server_ordering` - The layer ordering per server.
     /// * `trainer_spec` - The specification for the new trainer.
     ///
@@ -213,7 +213,7 @@ impl<T: TransportLayer> WorkerHandle<T> {
     }
 
     /// Tells the worker to switch algorithm to parameter server
-    /// by switch this particular node into a `ParameterServer`.
+    /// by switching this particular node into a `ParameterServer`.
     ///
     /// Consumes `self` and yields a new `ParameterServerHandle`.
     ///

--- a/comms/src/handles/worker.rs
+++ b/comms/src/handles/worker.rs
@@ -191,6 +191,7 @@ impl<T: TransportLayer> WorkerHandle<T> {
     /// * `server_addrs` - The network addresses of the servers.
     /// * `server_sizes` - The sizes in amount of paremters per server.
     /// * `server_ordering` - The layer ordering per server.
+    /// * `trainer_spec` - The specification for the new trainer.
     ///
     /// # Returns
     /// An io error if occurred.

--- a/comms/src/handles/worker.rs
+++ b/comms/src/handles/worker.rs
@@ -5,9 +5,11 @@ use tokio::io::AsyncRead;
 
 use super::{Compressor, compressor::CompressedGrad};
 use crate::{
+    ParamServerHandle,
     floats::Float01,
     protocol::{Command, Msg, Payload},
     share_dataset, sparse,
+    specs::server::ServerSpec,
     transport::TransportLayer,
 };
 
@@ -180,6 +182,53 @@ impl<T: TransportLayer> WorkerHandle<T> {
             &mut self.transport,
         )
         .await
+    }
+
+    /// Tells the worker to switch algorithm to parameter server
+    /// by switching this particular node into a `ParameterServerWorker`.
+    ///
+    /// # Args
+    /// * `server_addrs` - The network addresses of the servers.
+    /// * `server_sizes` - The sizes in amount of paremters per server.
+    /// * `server_ordering` - The layer ordering per server.
+    ///
+    /// # Returns
+    /// An io error if occurred.
+    pub async fn switch(
+        &mut self,
+        server_addrs: Vec<String>,
+        server_sizes: Vec<usize>,
+        server_ordering: Vec<usize>,
+    ) -> io::Result<()> {
+        let msg = Msg::Control(Command::Switch {
+            server_addrs,
+            server_sizes,
+            server_ordering,
+        });
+
+        self.transport.send(&msg).await
+    }
+
+    /// Tells the worker to switch algorithm to parameter server
+    /// by switch this particular node into a `ParameterServer`.
+    ///
+    /// Consumes `self` and yields a new `ParameterServerHandle`.
+    ///
+    /// # Args
+    /// * `spec` - The server specification.
+    /// * `ranges` - The ranges of parameters to store as a server.
+    ///
+    /// # Returns
+    /// A new `ParameterServerHandle` instance that shares the old transport connection.
+    pub async fn upgrade(
+        mut self,
+        spec: ServerSpec,
+        ranges: Vec<(usize, usize)>,
+    ) -> io::Result<ParamServerHandle<T>> {
+        let msg = Msg::Control(Command::Upgrade { spec, ranges });
+        self.transport.send(&msg).await?;
+
+        Ok(ParamServerHandle::new(self.id, self.transport))
     }
 
     /// Tells the worker to stop it's execution.

--- a/comms/src/handles/worker.rs
+++ b/comms/src/handles/worker.rs
@@ -9,7 +9,7 @@ use crate::{
     floats::Float01,
     protocol::{Command, Msg, Payload},
     share_dataset, sparse,
-    specs::server::ServerSpec,
+    specs::{machine_learning::TrainerSpec, server::ServerSpec},
     transport::TransportLayer,
 };
 
@@ -199,11 +199,13 @@ impl<T: TransportLayer> WorkerHandle<T> {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     ) -> io::Result<()> {
         let msg = Msg::Control(Command::Switch {
             server_addrs,
             server_sizes,
             server_ordering,
+            trainer_spec,
         });
 
         self.transport.send(&msg).await

--- a/comms/src/protocol/msg.rs
+++ b/comms/src/protocol/msg.rs
@@ -3,6 +3,8 @@ use std::{borrow::Cow, io};
 use half::f16;
 use serde::{Deserialize, Serialize};
 
+use crate::specs::machine_learning::TrainerSpec;
+
 use super::specs::{node::NodeSpec, server::ServerSpec};
 
 pub type Header = u32;
@@ -45,6 +47,7 @@ pub enum Command<'a> {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     },
     ReportLoss {
         losses: Cow<'a, [f64]>,

--- a/comms/src/protocol/specs/server.rs
+++ b/comms/src/protocol/specs/server.rs
@@ -19,7 +19,7 @@ pub enum StoreSpec {
 }
 
 /// The specification for the `Server` trait.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerSpec {
     pub id: usize,
     pub nworkers: usize,

--- a/comms/src/protocol/specs/worker.rs
+++ b/comms/src/protocol/specs/worker.rs
@@ -28,7 +28,7 @@ pub enum SerializerSpec {
 }
 
 /// The specification for the `Worker`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerSpec {
     pub worker_id: usize,
     pub trainer: TrainerSpec,

--- a/comms/src/transport/framer.rs
+++ b/comms/src/transport/framer.rs
@@ -11,6 +11,7 @@ use crate::{
 /// The `Framer` builds framed messages by prefixing the payload with it's size.
 ///
 /// It's the last layer of the entire transport layer stack.
+#[derive(Debug)]
 pub struct Framer<R, W>
 where
     R: AsyncRead + Unpin,

--- a/comms/src/transport/retryer.rs
+++ b/comms/src/transport/retryer.rs
@@ -6,6 +6,7 @@ use super::TransportLayer;
 use crate::protocol::Msg;
 
 /// The `Retryer` retries sending and receiving messages using exponential backoff.
+#[derive(Debug)]
 pub struct Retryer<L: TransportLayer> {
     base_retry_dur: Duration,
     retry_coef: u32,

--- a/comms/src/transport/timeouter.rs
+++ b/comms/src/transport/timeouter.rs
@@ -7,6 +7,7 @@ use crate::protocol::Msg;
 
 /// The `TimeOuter` tries receiving messages inside a time window.
 /// If it fails it returns an error with `ErrorKind::TimedOut`.
+#[derive(Debug)]
 pub struct TimeOuter<L: TransportLayer> {
     timeout: Duration,
     inner: L,

--- a/machine_learning/Cargo.toml
+++ b/machine_learning/Cargo.toml
@@ -14,3 +14,6 @@ rand = "0.9.2"
 rand_distr = "0.5.1"
 rayon = "1.11.0"
 tokio = { version = "1.49.0", features = ["full"] }
+
+[lints]
+workspace = true

--- a/machine_learning/src/arch/layers/conv2d.rs
+++ b/machine_learning/src/arch/layers/conv2d.rs
@@ -410,7 +410,6 @@ mod tests {
         assert_eq!(conv.dilated, delta);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn test_conv2d_forward(
         filters: usize,
         in_channels: usize,

--- a/machine_learning/src/datasets/dataset.rs
+++ b/machine_learning/src/datasets/dataset.rs
@@ -111,8 +111,20 @@ impl Dataset {
         })
     }
 
+    /// Retrieves both sizes for the samples and the labels.
+    ///
+    /// # Returns
+    /// The amout of samples and the amount of labels.
     pub fn sizes(&self) -> (NonZeroUsize, NonZeroUsize) {
         (self.x_size, self.y_size)
+    }
+
+    /// Consumes self and yields it's data source.
+    ///
+    /// # Returns
+    /// This dataset's data source.
+    pub fn into_src(self) -> DataSrc {
+        self.src
     }
 
     /// Creates a view over a certain batch of the dataset.

--- a/machine_learning/src/datasets/inmem_src.rs
+++ b/machine_learning/src/datasets/inmem_src.rs
@@ -48,9 +48,9 @@ impl InMemSrc {
     /// * `src` - The data to append.
     pub fn load(&mut self, src: DataSrc) {
         match src {
-            DataSrc::InMem(mut src) => {
-                self.samples.extend_from_slice(&mut src.samples);
-                self.labels.extend_from_slice(&mut src.labels)
+            DataSrc::InMem(src) => {
+                self.samples.extend_from_slice(&src.samples);
+                self.labels.extend_from_slice(&src.labels)
             }
         }
     }

--- a/machine_learning/src/test.rs
+++ b/machine_learning/src/test.rs
@@ -347,7 +347,6 @@ fn test_machine_learning04_xor4_gate_convergence() {
     // println!("loss: {loss}");
 }
 
-#[allow(clippy::too_many_arguments)]
 fn test_conv_dense(
     filters: usize,
     in_channels: usize,

--- a/machine_learning/src/training/backprop_trainer.rs
+++ b/machine_learning/src/training/backprop_trainer.rs
@@ -4,11 +4,11 @@ use rand::Rng;
 
 use super::{TrainResult, Trainer};
 use crate::{
-    Result,
-    arch::{Sequential, loss::LossFn},
+    arch::{loss::LossFn, Sequential},
     datasets::{DataSrc, Dataset},
     optimization::{GradientDescent, Optimizer},
     param_manager::ParamManager,
+    Result,
 };
 
 /// A model `Trainer`. Contains the relevant components needed for training a model,
@@ -54,7 +54,6 @@ where
     ///
     /// # Returns
     /// A new `BackpropTrainer` instance.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         model: Sequential,
         optimizers: Vec<O>,

--- a/machine_learning/src/training/backprop_trainer.rs
+++ b/machine_learning/src/training/backprop_trainer.rs
@@ -4,11 +4,11 @@ use rand::Rng;
 
 use super::{TrainResult, Trainer};
 use crate::{
-    arch::{loss::LossFn, Sequential},
+    Result,
+    arch::{Sequential, loss::LossFn},
     datasets::{DataSrc, Dataset},
     optimization::{GradientDescent, Optimizer},
     param_manager::ParamManager,
-    Result,
 };
 
 /// A model `Trainer`. Contains the relevant components needed for training a model,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { version = "1", features = [
   "signal",
   "sync",
 ] }
+
+[lints]
+workspace = true

--- a/node/src/router.rs
+++ b/node/src/router.rs
@@ -2,10 +2,12 @@ use std::io;
 
 use comms::{
     Acceptor, Connection, Connector, OrchHandle, TransportLayer, share_dataset,
-    specs::{node::NodeSpec, server::ServerSpec, worker::WorkerSpec},
+    specs::{
+        machine_learning::TrainerSpec, node::NodeSpec, server::ServerSpec, worker::WorkerSpec,
+    },
 };
 use log::{error, info, warn};
-use machine_learning::{datasets::Dataset, training::Trainer};
+use machine_learning::datasets::Dataset;
 use parameter_server::service::{Server, ServerBuilder};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -138,15 +140,19 @@ where
                 server_addrs,
                 server_sizes,
                 server_ordering,
+                trainer_spec,
             } => {
                 let trainer = worker.into_trainer();
+                let dataset = trainer.into_dataset();
+
                 let mut worker = self
                     .switch(
                         spec,
                         server_addrs,
                         server_sizes,
                         server_ordering,
-                        trainer,
+                        dataset,
+                        trainer_spec,
                         &mut orch_handle,
                     )
                     .await?;
@@ -201,7 +207,8 @@ where
     /// * `server_addrs` - The network addresses of the server nodes.
     /// * `server_sizes` - The sizes of each server node.
     /// * `server_ordering` - The ordering of server layers.
-    /// * `trainer` - The trainer used to train until now.
+    /// * `dataset` - The dataset that was being used by the worker until now.
+    /// * `trainer_spec` - The specification for the new trainer.
     /// * `orch_handle` - The handle for communicating with the orchestrator.
     ///
     /// # Returns
@@ -212,17 +219,20 @@ where
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
-        trainer: Box<dyn Trainer>,
+        dataset: Dataset,
+        trainer_spec: TrainerSpec,
         orch_handle: &'a mut OrchHandle<T>,
     ) -> io::Result<ParamServerWorker<'a, T>> {
         let mut worker_builder = WorkerBuilder::new(&mut self.acceptor, self.connector.clone());
+
         let worker = worker_builder
             .build_switched(
                 spec,
                 server_addrs,
                 server_sizes,
                 server_ordering,
-                trainer,
+                dataset,
+                trainer_spec,
                 orch_handle,
             )
             .await?;

--- a/orchestra-py/Cargo.toml
+++ b/orchestra-py/Cargo.toml
@@ -12,3 +12,6 @@ comms = { path = "../comms" }
 orchestrator = { path = "../orchestrator" }
 pyo3 = { version = "0.28.3", features = ["extension-module"] }
 tokio = { version = "1", features = ["full"] }
+
+[lints]
+workspace = true

--- a/orchestra-py/pyproject.toml
+++ b/orchestra-py/pyproject.toml
@@ -9,3 +9,6 @@ version = "0.1.0"
 [tool.maturin]
 python-packages = ["orchestra"]
 module-name = "orchestra._orchestra"
+
+[lints]
+workspace = true

--- a/orchestra-py/src/lib.rs
+++ b/orchestra-py/src/lib.rs
@@ -53,6 +53,7 @@ fn _orchestra(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<training::PyTrainingConfig>()?;
     m.add_function(wrap_pyfunction!(training::parameter_server, m)?)?;
     m.add_function(wrap_pyfunction!(training::all_reduce, m)?)?;
+    m.add_function(wrap_pyfunction!(training::strategy_switch, m)?)?;
     m.add_function(wrap_pyfunction!(training::orchestrate, m)?)?;
 
     Ok(())

--- a/orchestra-py/src/training.rs
+++ b/orchestra-py/src/training.rs
@@ -349,6 +349,186 @@ pub fn all_reduce(
     })
 }
 
+/// Builds a Strategy Switch training configuration.
+///
+/// Starts with AllReduce (all nodes participate) and switches to Parameter Server
+/// once the training's relative loss improvement drops below the internal threshold.
+/// The `server_addrs` nodes begin as AllReduce workers and are upgraded to Parameter
+/// Servers when the switch triggers.
+///
+/// # Args
+/// * `worker_addrs` - List of permanent worker addresses (e.g. `["127.0.0.1:50000"]`).
+/// * `server_addrs` - List of addresses that will become parameter servers after the switch.
+/// * `dataset` - The dataset to train on. Accepts either an `InlineDataset` or a `LocalDataset`.
+/// * `optimizer` - The optimizer to use.
+/// * `loss_fn` - The loss function to use. Accepts either `Mse()` or `CrossEntropy()`.
+/// * `sync` - Synchronization strategy for the PS phase (`BarrierSync()` or `NonBlockingSync()`).
+/// * `store` - Parameter store strategy for the PS phase (`BlockingStore()` or `WildStore()`).
+/// * `max_epochs` - Maximum number of training epochs.
+/// * `batch_size` - Mini-batch size.
+/// * `serializer` - Gradient serializer strategy. Accepts either `BaseSerializer()` or `SparseSerializer(r=...)`. Defaults to `BaseSerializer()`.
+/// * `offline_epochs` - Extra local epochs per sync round. Defaults to `0`.
+/// * `seed` - Optional random seed for reproducibility.
+/// * `early_stopping_tolerance` - If set, training stops when the loss improvement is below this value. Defaults to `None`.
+///
+/// # Returns
+/// A `PyTrainingConfig` ready to be passed to `orchestrate(...)`.
+///
+/// # Errors
+/// Raises a `ValueError` if required fields are invalid.
+/// Raises a `TypeError` if any argument has the wrong type.
+#[pyfunction]
+#[pyo3(signature = (
+    worker_addrs,
+    server_addrs,
+    dataset,
+    optimizer,
+    loss_fn,
+    sync,
+    store,
+    max_epochs,
+    batch_size,
+    serializer = None,
+    offline_epochs = 0,
+    seed = None,
+    early_stopping_tolerance = None,
+))]
+pub fn strategy_switch(
+    worker_addrs: Vec<String>,
+    server_addrs: Vec<String>,
+    dataset: &Bound<'_, PyAny>,
+    optimizer: PyRef<GradientDescent>,
+    loss_fn: &Bound<'_, PyAny>,
+    sync: &Bound<'_, PyAny>,
+    store: &Bound<'_, PyAny>,
+    max_epochs: usize,
+    batch_size: usize,
+    serializer: Option<&Bound<'_, PyAny>>,
+    offline_epochs: usize,
+    seed: Option<u64>,
+    early_stopping_tolerance: Option<f64>,
+) -> PyResult<PyTrainingConfig> {
+    let max_epochs_nz = NonZeroUsize::new(max_epochs)
+        .ok_or_else(|| PyValueError::new_err("max_epochs must be greater than 0"))?;
+
+    let batch_size_nz = NonZeroUsize::new(batch_size)
+        .ok_or_else(|| PyValueError::new_err("batch_size must be greater than 0"))?;
+
+    let early_stopping = match early_stopping_tolerance {
+        Some(tolerance) if tolerance.is_sign_negative() || tolerance == 0.0 => {
+            return Err(PyValueError::new_err(
+                "early stopping tolerance must be a non negative number",
+            ))
+        }
+        Some(tolerance) => {
+            let tolerance = FloatNonNegative::new(tolerance).unwrap();
+            Some(EarlyStoppingConfig { tolerance })
+        }
+        None => None,
+    };
+
+    let synchronizer = if sync.is_instance_of::<BarrierSync>() {
+        SynchronizerConfig::Barrier
+    } else if sync.is_instance_of::<NonBlockingSync>() {
+        SynchronizerConfig::NonBlocking
+    } else {
+        return Err(PyTypeError::new_err(
+            "sync must be BarrierSync() or NonBlockingSync()",
+        ));
+    };
+
+    let store_cfg = if store.is_instance_of::<BlockingStore>() {
+        StoreConfig::Blocking
+    } else if store.is_instance_of::<WildStore>() {
+        StoreConfig::Wild
+    } else {
+        return Err(PyTypeError::new_err(
+            "store must be BlockingStore() or WildStore()",
+        ));
+    };
+
+    let loss_fn_cfg = if loss_fn.is_instance_of::<Mse>() {
+        LossFnConfig::Mse
+    } else if loss_fn.is_instance_of::<CrossEntropy>() {
+        LossFnConfig::CrossEntropy
+    } else {
+        return Err(PyTypeError::new_err(
+            "loss_fn must be Mse() or CrossEntropy()",
+        ));
+    };
+
+    let serializer_cfg = match serializer {
+        None => SerializerConfig::Base,
+        Some(serializer) if serializer.is_instance_of::<BaseSerializer>() => SerializerConfig::Base,
+        Some(serializer) => {
+            if let Ok(sparse) = serializer.extract::<PyRef<SparseSerializer>>() {
+                SerializerConfig::SparseCapable { r: sparse.r }
+            } else {
+                return Err(PyTypeError::new_err(
+                    "serializer must be BaseSerializer() or SparseSerializer(r=...)",
+                ));
+            }
+        }
+    };
+
+    let dataset_config = if let Ok(d) = dataset.extract::<PyRef<InlineDataset>>() {
+        DatasetConfig {
+            src: DataSrc::Inline {
+                samples: d.samples.clone(),
+                labels: d.labels.clone(),
+            },
+            x_size: d.x_size,
+            y_size: d.y_size,
+        }
+    } else if let Ok(d) = dataset.extract::<PyRef<LocalDataset>>() {
+        DatasetConfig {
+            src: DataSrc::Local {
+                samples_path: d.samples_path.clone(),
+                labels_path: d.labels_path.clone(),
+            },
+            x_size: d.x_size,
+            y_size: d.y_size,
+        }
+    } else {
+        return Err(PyTypeError::new_err(
+            "dataset must be an InlineDataset or LocalDataset",
+        ));
+    };
+
+    if optimizer.lr <= 0.0 {
+        return Err(PyValueError::new_err(
+            "learning rate must be a positive number",
+        ));
+    }
+
+    // All nodes start as AllReduce workers, so worker_count is the full entity count.
+    let worker_count = worker_addrs.len() + server_addrs.len();
+
+    Ok(PyTrainingConfig {
+        inner: TrainingConfig {
+            worker_addrs,
+            algorithm: AlgorithmConfig::StrategySwitch {
+                server_addrs,
+                synchronizer,
+                store: store_cfg,
+            },
+            serializer: serializer_cfg,
+            dataset: dataset_config,
+            optimizer: OptimizerConfig::GradientDescent {
+                lr: FloatPositive::new(optimizer.lr).unwrap(),
+            },
+            loss_fn: loss_fn_cfg,
+            batch_size: batch_size_nz,
+            max_epochs: max_epochs_nz,
+            offline_epochs,
+            seed,
+            early_stopping,
+        },
+        max_epochs,
+        worker_count,
+    })
+}
+
 /// Starts a distributed training session and returns a `Session` handle.
 ///
 /// # Args

--- a/orchestra-py/src/training.rs
+++ b/orchestra-py/src/training.rs
@@ -71,7 +71,6 @@ pub struct PyTrainingConfig {
     seed = None,
     early_stopping_tolerance = None,
 ))]
-#[allow(clippy::too_many_arguments)]
 pub fn parameter_server(
     worker_addrs: Vec<String>,
     server_addrs: Vec<String>,
@@ -242,7 +241,6 @@ pub fn parameter_server(
     seed = None,
     early_stopping_tolerance = None,
 ))]
-#[allow(clippy::too_many_arguments)]
 pub fn all_reduce(
     worker_addrs: Vec<String>,
     dataset: &Bound<'_, PyAny>,

--- a/orchestra-py/src/training.rs
+++ b/orchestra-py/src/training.rs
@@ -85,7 +85,7 @@ pub fn parameter_server(
     serializer: Option<&Bound<'_, PyAny>>,
     offline_epochs: usize,
     seed: Option<u64>,
-    early_stopping_tolerance: Option<f32>,
+    early_stopping_tolerance: Option<f64>,
 ) -> PyResult<PyTrainingConfig> {
     let max_epochs_nz = NonZeroUsize::new(max_epochs)
         .ok_or_else(|| PyValueError::new_err("max_epochs must be greater than 0"))?;
@@ -253,7 +253,7 @@ pub fn all_reduce(
     serializer: Option<&Bound<'_, PyAny>>,
     offline_epochs: usize,
     seed: Option<u64>,
-    early_stopping_tolerance: Option<f32>,
+    early_stopping_tolerance: Option<f64>,
 ) -> PyResult<PyTrainingConfig> {
     let max_epochs_nz = NonZeroUsize::new(max_epochs)
         .ok_or_else(|| PyValueError::new_err("max_epochs must be greater than 0"))?;

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = "1"
 futures = "0.3.32"
 safetensors = "0.4"
 bytemuck = "1"
+
+[lints]
+workspace = true

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -11,7 +11,10 @@ use comms::specs::{
     worker::{AlgorithmSpec, SerializerSpec, WorkerSpec},
 };
 
-use super::{ModelConfig, SerializerConfig, TrainingConfig, partition::Partition};
+use super::{
+    ModelConfig, Partition, SerializerConfig, ServerAdapt, TrainingConfig, WorkerAdapt,
+    WorkerPostAction,
+};
 use crate::{
     configs::{
         ActFnConfig, AlgorithmConfig, DataSrc, DatasetConfig, LayerConfig, LossFnConfig,
@@ -44,22 +47,22 @@ impl Adapter {
     ///
     /// # Errors
     /// An `OrchErr` if the configs fail to be adapted.
-    #[allow(clippy::type_complexity)]
     pub fn adapt_configs<'a>(
         &self,
         model: ModelConfig,
         training: &'a TrainingConfig,
-    ) -> Result<(
-        Vec<(String, WorkerSpec, Partition<'a>)>,
-        Vec<(String, ServerSpec)>,
-    )> {
+    ) -> Result<(Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>)> {
         let partitions =
             self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
 
-        let (workers, servers) = match &training.algorithm {
-            AlgorithmConfig::ParameterServer { .. } => {
-                let (servers, server_addrs, server_sizes, server_ordering) =
-                    self.adapt_servers(&model, training)?;
+        let (workers, servers) = match training.algorithm {
+            AlgorithmConfig::ParameterServer {
+                ref server_addrs,
+                synchronizer,
+                store,
+            } => {
+                let (servers, server_sizes, server_ordering) =
+                    self.adapt_servers(&model, training, server_addrs, synchronizer, store)?;
 
                 let workers = self.adapt_parameter_server_workers(
                     &model,
@@ -67,21 +70,32 @@ impl Adapter {
                     server_addrs,
                     server_sizes,
                     server_ordering,
+                    partitions,
                 )?;
 
                 (workers, servers)
             }
             AlgorithmConfig::AllReduce => {
-                let workers = self.adapt_all_reduce_workers(&model, training)?;
+                let workers = self.adapt_all_reduce_workers(&model, training, partitions)?;
+                (workers, Vec::new())
+            }
+            AlgorithmConfig::StrategySwitch {
+                ref server_addrs,
+                synchronizer,
+                store,
+            } => {
+                let workers = self.adapt_strategy_switch_workers(
+                    &model,
+                    training,
+                    server_addrs.clone(),
+                    synchronizer,
+                    store,
+                    partitions,
+                )?;
+
                 (workers, Vec::new())
             }
         };
-
-        let workers = workers
-            .into_iter()
-            .zip(partitions)
-            .map(|((addr, spec), partition)| (addr, spec, partition))
-            .collect();
 
         Ok((workers, servers))
     }
@@ -94,33 +108,36 @@ impl Adapter {
     /// * `server_addrs` - Already-resolved server socket addresses.
     /// * `server_sizes` - The amounts of parameters per server.
     /// * `server_ordering` - The ordering of the layer owners.
+    /// * `partitions` - The dataset partitions.
     ///
     /// # Returns
     /// Worker addresses and specifications.
     ///
     /// # Errors
     /// Returns an `OrchErr` if any address cannot be resolved.
-    fn adapt_parameter_server_workers(
+    fn adapt_parameter_server_workers<'a>(
         &self,
         model: &ModelConfig,
-        training: &TrainingConfig,
-        server_addrs: Vec<String>,
+        training: &'a TrainingConfig,
+        server_addrs: &[String],
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
-    ) -> Result<Vec<(String, WorkerSpec)>> {
+        partitions: Vec<Partition<'a>>,
+    ) -> Result<Vec<WorkerAdapt<'a>>> {
         let trainer_spec = self.adapt_trainer(model, training);
         let serializer_spec = self.adapt_serializer(training);
         let algorithm_spec = AlgorithmSpec::ParameterServer {
-            server_addrs,
+            server_addrs: server_addrs.to_vec(),
             server_sizes,
             server_ordering,
         };
 
-        let worker_specs = training
+        let workers = training
             .worker_addrs
             .iter()
+            .zip(partitions)
             .enumerate()
-            .map(|(i, addr)| {
+            .map(|(i, (addr, partition))| {
                 if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
                     let text = format!("failed to resolve {i}'th worker's network address: {addr}");
                     return Err(OrchErr::InvalidConfig(text));
@@ -134,11 +151,18 @@ impl Adapter {
                     seed: training.seed,
                 };
 
-                Ok((addr.clone(), worker_spec))
+                let worker_adapt = WorkerAdapt {
+                    addr: addr.clone(),
+                    spec: worker_spec,
+                    partition,
+                    post_action: None,
+                };
+
+                Ok(worker_adapt)
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(worker_specs)
+        Ok(workers)
     }
 
     /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerSpec`.
@@ -146,17 +170,19 @@ impl Adapter {
     /// # Args
     /// * `model` - The model's configuration.
     /// * `training` - The training's configuration.
+    /// * `partitions` - The dataset partitions.
     ///
     /// # Returns
     /// Worker addresses and specifications.
     ///
     /// # Errors
     /// Returns an `OrchErr` if any address cannot be resolved.
-    fn adapt_all_reduce_workers(
+    fn adapt_all_reduce_workers<'a>(
         &self,
         model: &ModelConfig,
         training: &TrainingConfig,
-    ) -> Result<Vec<(String, WorkerSpec)>> {
+        partitions: Vec<Partition<'a>>,
+    ) -> Result<Vec<WorkerAdapt<'a>>> {
         let trainer_spec = self.adapt_trainer(model, training);
         let (_, param_gen_specs) = self.adapt_layers(model, training.dataset.x_size);
         let algorithm_spec = AlgorithmSpec::AllReduce {
@@ -168,11 +194,12 @@ impl Adapter {
         };
         let serializer_spec = self.adapt_serializer(training);
 
-        let worker_specs = training
+        let workers = training
             .worker_addrs
             .iter()
+            .zip(partitions)
             .enumerate()
-            .map(|(i, addr)| {
+            .map(|(i, (addr, partition))| {
                 if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
                     let text = format!("failed to resolve {i}'th worker's network address: {addr}");
                     return Err(OrchErr::InvalidConfig(text));
@@ -186,11 +213,132 @@ impl Adapter {
                     seed: training.seed,
                 };
 
-                Ok((addr.clone(), worker_spec))
+                let worker_adapt = WorkerAdapt {
+                    addr: addr.clone(),
+                    spec: worker_spec,
+                    partition,
+                    post_action: None,
+                };
+
+                Ok(worker_adapt)
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(worker_specs)
+        Ok(workers)
+    }
+
+    /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerSpec`.
+    ///
+    /// # Args
+    /// * `model` - The model's configuration.
+    /// * `training` - The training's configuration.
+    /// * `server_addrs` - Already-resolved server socket addresses.
+    /// * `partitions` - The dataset partitions.
+    ///
+    /// # Returns
+    /// Worker addresses and specifications.
+    ///
+    /// # Errors
+    /// Returns an `OrchErr` if any address cannot be resolved.
+    fn adapt_strategy_switch_workers<'a>(
+        &self,
+        model: &ModelConfig,
+        training: &TrainingConfig,
+        server_addrs: Vec<String>,
+        synchronizer: SynchronizerConfig,
+        store: StoreConfig,
+        partitions: Vec<Partition<'a>>,
+    ) -> Result<Vec<WorkerAdapt<'a>>> {
+        let serializer_spec = self.adapt_serializer(&training);
+        let (servers, server_sizes, server_ordering) =
+            self.adapt_servers(model, training, &server_addrs, synchronizer, store)?;
+
+        let nworkers = training.worker_addrs.len();
+        let trainer_spec = self.adapt_trainer(model, training);
+        let (_, param_gen_specs) = self.adapt_layers(model, training.dataset.x_size);
+        let algorithm_spec = AlgorithmSpec::AllReduce {
+            worker_addrs: training.worker_addrs.clone(),
+            param_gen: ParamGenSpec::Chained {
+                specs: param_gen_specs,
+            },
+            amount_of_layers: model.layers.len(),
+        };
+
+        let worker_workers = training
+            .worker_addrs
+            .iter()
+            .zip(&partitions[..nworkers])
+            .enumerate()
+            .map(|(i, (addr, partition))| {
+                if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
+                    let text = format!("failed to resolve {i}'th worker's network address: {addr}");
+                    return Err(OrchErr::InvalidConfig(text));
+                }
+
+                let worker_spec = WorkerSpec {
+                    worker_id: i,
+                    trainer: trainer_spec.clone(),
+                    algorithm: algorithm_spec.clone(),
+                    serializer: serializer_spec,
+                    seed: training.seed,
+                };
+
+                let post_action = WorkerPostAction::Switch {
+                    server_addrs: server_addrs.clone(),
+                    server_sizes: server_sizes.clone(),
+                    server_ordering: server_ordering.clone(),
+                };
+
+                let worker_adapt = WorkerAdapt {
+                    addr: addr.clone(),
+                    spec: worker_spec,
+                    partition: partition.clone(),
+                    post_action: Some(post_action),
+                };
+
+                Ok(worker_adapt)
+            });
+
+        let worker_servers = servers
+            .into_iter()
+            .zip(&partitions[nworkers..])
+            .enumerate()
+            .map(|(i, (server_adapt, partition))| {
+                let ServerAdapt {
+                    addr,
+                    spec: server_spec,
+                } = server_adapt;
+
+                if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
+                    let text = format!("failed to resolve {i}'th worker's network address: {addr}");
+                    return Err(OrchErr::InvalidConfig(text));
+                }
+
+                let worker_spec = WorkerSpec {
+                    worker_id: i,
+                    trainer: trainer_spec.clone(),
+                    algorithm: algorithm_spec.clone(),
+                    serializer: serializer_spec,
+                    seed: training.seed,
+                };
+
+                let post_action = WorkerPostAction::Upgrade { spec: server_spec };
+
+                let worker_adapt = WorkerAdapt {
+                    addr: addr.clone(),
+                    spec: worker_spec,
+                    partition: partition.clone(),
+                    post_action: Some(post_action),
+                };
+
+                Ok(worker_adapt)
+            });
+
+        let workers = worker_workers
+            .chain(worker_servers)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(workers)
     }
 
     /// Adapts the training's configurations into a `SerializerSpec`.
@@ -212,6 +360,9 @@ impl Adapter {
     /// # Args
     /// * `model` - The model's architecture and initialization configuration.
     /// * `training` - The training's configuration.
+    /// * `server_addrs` - The server' network addresses.
+    /// * `synchronizer` - The synchronizer's configuration.
+    /// * `store` - The store's configuration.
     ///
     /// # Returns
     /// The servers' specifications, resolved addresses, sizes and layers' ordering.
@@ -223,23 +374,55 @@ impl Adapter {
         &self,
         model: &ModelConfig,
         training: &TrainingConfig,
-    ) -> Result<(
-        Vec<(String, ServerSpec)>,
-        Vec<String>,
-        Vec<usize>,
-        Vec<usize>,
-    )> {
-        let AlgorithmConfig::ParameterServer {
-            server_addrs,
-            synchronizer,
-            store,
-            ..
-        } = &training.algorithm
-        else {
-            let text = "all-reduce does not use parameter servers".into();
-            return Err(OrchErr::Unsupported(text));
-        };
+        server_addrs: &[String],
+        synchronizer: SynchronizerConfig,
+        store: StoreConfig,
+    ) -> Result<(Vec<ServerAdapt>, Vec<usize>, Vec<usize>)> {
+        let (param_gens, server_sizes, server_ordering) =
+            self.adapt_param_gens(model, training, server_addrs.len())?;
 
+        let nworkers = training.worker_addrs.len();
+        let (servers, server_sizes): (Vec<_>, Vec<_>) = server_addrs
+            .iter()
+            .zip(param_gens)
+            .zip(server_sizes)
+            .enumerate()
+            .map(|(i, ((addr, param_gen_spec), size))| {
+                if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
+                    let text = format!("failed to resolve {i}'th server's network address: {addr}");
+                    return Err(OrchErr::InvalidConfig(text));
+                }
+
+                let server_spec = ServerSpec {
+                    id: i,
+                    nworkers: training.worker_addrs.len(),
+                    param_gen: param_gen_spec,
+                    optimizer: self.adapt_optimizer(training.optimizer),
+                    synchronizer: self.adapt_synchronizer(&synchronizer, nworkers),
+                    store: self.adapt_store(&store),
+                    seed: training.seed,
+                };
+
+                let adapt = ServerAdapt {
+                    addr: addr.clone(),
+                    spec: server_spec,
+                };
+
+                Ok((adapt, size))
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .unzip();
+
+        Ok((servers, server_sizes, server_ordering))
+    }
+
+    fn adapt_param_gens(
+        &self,
+        model: &ModelConfig,
+        training: &TrainingConfig,
+        nservers: usize,
+    ) -> Result<(Vec<ParamGenSpec>, Vec<usize>, Vec<usize>)> {
         let (_, param_gens) = self.adapt_layers(model, training.dataset.x_size);
         let nlayers = param_gens.len();
 
@@ -252,7 +435,7 @@ impl Adapter {
             })
             .collect();
 
-        let param_gen_bins = balanced_partitions(items, server_addrs.len());
+        let param_gen_bins = balanced_partitions(items, nservers);
         let mut server_ordering = vec![0; nlayers];
 
         for (server_i, bin) in param_gen_bins.iter().enumerate() {
@@ -274,35 +457,8 @@ impl Adapter {
             (chained, sizes.into_iter().sum::<usize>())
         });
 
-        let nworkers = training.worker_addrs.len();
-        let (servers, server_sizes): (Vec<_>, Vec<_>) = server_addrs
-            .iter()
-            .zip(chained_param_gens)
-            .enumerate()
-            .map(|(i, (addr, (param_gen_spec, size)))| {
-                if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
-                    let text = format!("failed to resolve {i}'th server's network address: {addr}");
-                    return Err(OrchErr::InvalidConfig(text));
-                }
-
-                let server_spec = ServerSpec {
-                    id: i,
-                    nworkers: training.worker_addrs.len(),
-                    param_gen: param_gen_spec,
-                    optimizer: self.adapt_optimizer(training.optimizer),
-                    synchronizer: self.adapt_synchronizer(synchronizer, nworkers),
-                    store: self.adapt_store(store),
-                    seed: training.seed,
-                };
-
-                Ok(((addr.clone(), server_spec), size))
-            })
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .unzip();
-
-        let server_addrs = servers.iter().map(|(addr, _)| addr.clone()).collect();
-        Ok((servers, server_addrs, server_sizes, server_ordering))
+        let (param_gen_specs, server_sizes) = chained_param_gens.unzip();
+        Ok((param_gen_specs, server_sizes, server_ordering))
     }
 
     /// Adapts a `SynchronizerConfig` into a `SynchronizerSpec`.

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -52,9 +52,6 @@ impl Adapter {
         model: ModelConfig,
         training: &'a TrainingConfig,
     ) -> Result<(OrchAdapt, Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>)> {
-        let partitions =
-            self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
-
         let (orch, workers, servers) = match training.algorithm {
             AlgorithmConfig::ParameterServer {
                 ref server_addrs,
@@ -64,6 +61,9 @@ impl Adapter {
                 let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
                 let (servers, server_sizes, server_ordering) =
                     self.adapt_servers(&model, training, server_addrs, synchronizer, store)?;
+
+                let partitions =
+                    self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
 
                 let workers = self.adapt_parameter_server_workers(
                     &model,
@@ -78,6 +78,9 @@ impl Adapter {
             }
             AlgorithmConfig::AllReduce => {
                 let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
+                let partitions =
+                    self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
+
                 let workers = self.adapt_all_reduce_workers(&model, training, partitions)?;
                 (orch, workers, Vec::new())
             }
@@ -86,6 +89,7 @@ impl Adapter {
                 synchronizer,
                 store,
             } => {
+                let starting_workers = training.worker_addrs.len() + server_addrs.len();
                 let orch = self.adapt_strategy_switch_orch(
                     &model,
                     training,
@@ -93,6 +97,9 @@ impl Adapter {
                     synchronizer,
                     store,
                 )?;
+
+                let partitions =
+                    self.adapt_dataset_partitions(&training.dataset, starting_workers)?;
 
                 let workers = self.adapt_strategy_switch_workers(
                     &model,
@@ -362,8 +369,15 @@ impl Adapter {
         let nworkers = training.worker_addrs.len();
         let trainer_spec = self.adapt_trainer(model, training);
         let (_, param_gen_specs) = self.adapt_layers(model, training.dataset.x_size);
+        let addrs = training
+            .worker_addrs
+            .iter()
+            .chain(&server_addrs)
+            .cloned()
+            .collect();
+
         let algorithm_spec = AlgorithmSpec::AllReduce {
-            worker_addrs: training.worker_addrs.clone(),
+            worker_addrs: addrs,
             param_gen: ParamGenSpec::Chained {
                 specs: param_gen_specs,
             },

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -187,24 +187,26 @@ impl Adapter {
         let winsize = GreaterThanOneUsize::new(5).unwrap();
         let tracker = SwitchTracker::new(winsize, 0.01);
 
+        let trainer_spec = self.adapt_trainer(model, training);
         let (_, _, _, param_ranges) = self.adapt_param_gens(model, training, nservers)?;
         let (servers, server_sizes, server_ordering) =
             self.adapt_servers(model, training, server_addrs, synchronizer, store)?;
+
+        let switches = (0..nworkers).map(|_| WorkerPostAction::Switch {
+            server_addrs: server_addrs.to_vec(),
+            server_sizes: server_sizes.clone(),
+            server_ordering: server_ordering.clone(),
+            trainer_spec: trainer_spec.clone(),
+        });
 
         let upgrades = servers
             .into_iter()
             .zip(param_ranges)
             .map(|(ServerAdapt { spec, .. }, ranges)| WorkerPostAction::Upgrade { spec, ranges });
 
-        let switches = (0..nworkers).map(|_| WorkerPostAction::Switch {
-            server_addrs: server_addrs.to_vec(),
-            server_sizes: server_sizes.clone(),
-            server_ordering: server_ordering.clone(),
-        });
-
         let tracking = StrategySwitchTracking {
             tracker,
-            post_actions: upgrades.chain(switches).collect(),
+            post_actions: switches.chain(upgrades).collect(),
         };
 
         let adapt = OrchAdapt {
@@ -564,21 +566,39 @@ impl Adapter {
         }
 
         let chained_param_gens = param_gen_bins.into_iter().map(|bin| {
-            let (specs, sizes): (Vec<_>, Vec<_>) = bin
-                .into_iter()
-                .map(|(_, spec)| {
-                    let size = spec.size();
-                    (spec, size)
-                })
-                .unzip();
+            let mut specs = Vec::with_capacity(bin.len());
+            let mut local_ranges = Vec::with_capacity(bin.len());
+            let mut local_offset = 0;
 
+            for (_, spec) in bin {
+                let size = spec.size();
+                specs.push(spec);
+
+                local_ranges.push((local_offset, local_offset + size));
+                local_offset += size;
+            }
+
+            local_ranges.sort_unstable();
             let chained = ParamGenSpec::Chained { specs };
-            (chained, sizes.into_iter().sum::<usize>())
+            (chained, local_offset, local_ranges)
         });
 
-        let (param_gen_specs, server_sizes) = chained_param_gens.unzip();
-        let ranges = Vec::new();
-        Ok((param_gen_specs, server_sizes, server_ordering, ranges))
+        let mut param_gen_specs = Vec::new();
+        let mut server_sizes = Vec::new();
+        let mut server_ranges = Vec::new();
+
+        for (chained, size, ranges) in chained_param_gens {
+            param_gen_specs.push(chained);
+            server_sizes.push(size);
+            server_ranges.push(ranges);
+        }
+
+        Ok((
+            param_gen_specs,
+            server_sizes,
+            server_ordering,
+            server_ranges,
+        ))
     }
 
     /// Adapts a `SynchronizerConfig` into a `SynchronizerSpec`.

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -134,7 +134,6 @@ impl Adapter {
         };
 
         let convergence_tracker = training.early_stopping.map(|cfg| {
-            // SAFETY: The window size is greater than `1`.
             let winsize = GreaterThanOneUsize::new(3).unwrap();
             ConvergenceTracker::new(winsize, cfg.tolerance)
         });
@@ -178,12 +177,10 @@ impl Adapter {
         };
 
         let convergence_tracker = training.early_stopping.map(|cfg| {
-            // SAFETY: The window size is greater than `1`.
             let winsize = GreaterThanOneUsize::new(3).unwrap();
             ConvergenceTracker::new(winsize, cfg.tolerance)
         });
 
-        // SAFETY: The winsize is greater than `1`.
         let winsize = GreaterThanOneUsize::new(5).unwrap();
         let tracker = SwitchTracker::new(winsize, 0.01);
 

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -180,7 +180,7 @@ impl Adapter {
         let winsize = GreaterThanOneUsize::new(5).unwrap();
         let tracker = SwitchTracker::new(winsize, 0.01);
 
-        let (_, _, _, param_ranges) = self.adapt_param_gens(&model, training, nservers)?;
+        let (_, _, _, param_ranges) = self.adapt_param_gens(model, training, nservers)?;
         let (servers, server_sizes, server_ordering) =
             self.adapt_servers(model, training, server_addrs, synchronizer, store)?;
 
@@ -460,7 +460,6 @@ impl Adapter {
     ///
     /// # Errors
     /// Returns an `OrchErr` if any address cannot be resolved.
-    #[allow(clippy::type_complexity)]
     fn adapt_servers(
         &self,
         model: &ModelConfig,

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -11,14 +11,12 @@ use comms::specs::{
     worker::{AlgorithmSpec, SerializerSpec, WorkerSpec},
 };
 
-use super::{
-    ModelConfig, Partition, SerializerConfig, ServerAdapt, TrainingConfig, WorkerAdapt,
-    WorkerPostAction,
-};
+use super::{ModelConfig, Partition, SerializerConfig, ServerAdapt, TrainingConfig, WorkerAdapt};
 use crate::{
     configs::{
         ActFnConfig, AlgorithmConfig, DataSrc, DatasetConfig, LayerConfig, LossFnConfig,
-        OptimizerConfig, OrchAdapt, ParamGenConfig, StoreConfig, SynchronizerConfig,
+        OptimizerConfig, OrchAdapt, ParamGenConfig, StoreConfig, StrategySwitchTracking,
+        SynchronizerConfig, WorkerPostAction,
     },
     error::{OrchErr, Result},
     sessions::{ConvergenceTracker, GreaterThanOneUsize, LossRecorder, SwitchTracker},
@@ -44,7 +42,8 @@ impl Adapter {
     /// * `training` - The training's configuration.
     ///
     /// # Returns
-    /// The workers' and servers' specifications, network addresses and the workers' dataset partitions.
+    /// The workers' and servers' specifications, network addresses and the workers' dataset partitions with
+    /// the necessary information for the orchestrator to supervise the training.
     ///
     /// # Errors
     /// An `OrchErr` if the configs fail to be adapted.
@@ -52,16 +51,17 @@ impl Adapter {
         &self,
         model: ModelConfig,
         training: &'a TrainingConfig,
-    ) -> Result<(Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>, OrchAdapt)> {
+    ) -> Result<(OrchAdapt, Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>)> {
         let partitions =
             self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
 
-        let (workers, servers) = match training.algorithm {
+        let (orch, workers, servers) = match training.algorithm {
             AlgorithmConfig::ParameterServer {
                 ref server_addrs,
                 synchronizer,
                 store,
             } => {
+                let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
                 let (servers, server_sizes, server_ordering) =
                     self.adapt_servers(&model, training, server_addrs, synchronizer, store)?;
 
@@ -74,32 +74,38 @@ impl Adapter {
                     partitions,
                 )?;
 
-                (workers, servers)
+                (orch, workers, servers)
             }
             AlgorithmConfig::AllReduce => {
+                let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
                 let workers = self.adapt_all_reduce_workers(&model, training, partitions)?;
-                (workers, Vec::new())
+                (orch, workers, Vec::new())
             }
             AlgorithmConfig::StrategySwitch {
                 ref server_addrs,
                 synchronizer,
                 store,
             } => {
+                let orch = self.adapt_strategy_switch_orch(
+                    &model,
+                    training,
+                    server_addrs,
+                    synchronizer,
+                    store,
+                )?;
+
                 let workers = self.adapt_strategy_switch_workers(
                     &model,
                     training,
                     server_addrs.clone(),
-                    synchronizer,
-                    store,
                     partitions,
                 )?;
 
-                (workers, Vec::new())
+                (orch, workers, Vec::new())
             }
         };
 
-        let orch = self.adapt_orch(&model, training)?;
-        Ok((workers, servers, orch))
+        Ok((orch, workers, servers))
     }
 
     /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerAdapt`.
@@ -110,7 +116,11 @@ impl Adapter {
     ///
     /// # Returns
     /// An adapted orchestrator.
-    fn adapt_orch(&self, model: &ModelConfig, training: &TrainingConfig) -> Result<OrchAdapt> {
+    fn adapt_non_strategy_switch_orch(
+        &self,
+        model: &ModelConfig,
+        training: &TrainingConfig,
+    ) -> Result<OrchAdapt> {
         let Some(nworkers) = NonZeroUsize::new(training.worker_addrs.len()) else {
             let text = "The amount of workers must be positive";
             return Err(OrchErr::InvalidConfig(text.into()));
@@ -122,21 +132,79 @@ impl Adapter {
             ConvergenceTracker::new(winsize, cfg.tolerance)
         });
 
-        let switch_tracker = match training.algorithm {
-            AlgorithmConfig::StrategySwitch { .. } => {
-                // SAFETY: The winsize is greater than `1`.
-                let winsize = GreaterThanOneUsize::new(5).unwrap();
-                let tracker = SwitchTracker::new(winsize, 0.01);
-                Some(tracker)
-            }
-            _ => None,
-        };
-
         let adapt = OrchAdapt {
             input_size: training.dataset.x_size,
             loss_recorder: LossRecorder::new(nworkers),
             convergence_tracker,
-            switch_tracker,
+            switch_tracking: None,
+            model_config: model.clone(),
+            algorithm_config: training.algorithm.clone(),
+        };
+
+        Ok(adapt)
+    }
+
+    /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerSpec`.
+    ///
+    /// * `model` - The model's configuration.
+    /// * `training` - The training's configuration.
+    /// * `server_addrs` - Already-resolved server socket addresses.
+    /// * `server_sizes` - The amounts of parameters per server.
+    /// * `server_ordering` - The ordering of the layer owners.
+    ///
+    /// # Returns
+    /// An adapted orchestrator.
+    fn adapt_strategy_switch_orch(
+        &self,
+        model: &ModelConfig,
+        training: &TrainingConfig,
+        server_addrs: &[String],
+        synchronizer: SynchronizerConfig,
+        store: StoreConfig,
+    ) -> Result<OrchAdapt> {
+        let nworkers = training.worker_addrs.len();
+        let nservers = server_addrs.len();
+
+        let Some(nentities) = NonZeroUsize::new(nworkers + nservers) else {
+            let text = "The amount of entities must be positive";
+            return Err(OrchErr::InvalidConfig(text.into()));
+        };
+
+        let convergence_tracker = training.early_stopping.map(|cfg| {
+            // SAFETY: The window size is greater than `1`.
+            let winsize = GreaterThanOneUsize::new(3).unwrap();
+            ConvergenceTracker::new(winsize, cfg.tolerance)
+        });
+
+        // SAFETY: The winsize is greater than `1`.
+        let winsize = GreaterThanOneUsize::new(5).unwrap();
+        let tracker = SwitchTracker::new(winsize, 0.01);
+
+        let (_, _, _, param_ranges) = self.adapt_param_gens(&model, training, nservers)?;
+        let (servers, server_sizes, server_ordering) =
+            self.adapt_servers(model, training, server_addrs, synchronizer, store)?;
+
+        let upgrades = servers
+            .into_iter()
+            .zip(param_ranges)
+            .map(|(ServerAdapt { spec, .. }, ranges)| WorkerPostAction::Upgrade { spec, ranges });
+
+        let switches = (0..nworkers).map(|_| WorkerPostAction::Switch {
+            server_addrs: server_addrs.to_vec(),
+            server_sizes: server_sizes.clone(),
+            server_ordering: server_ordering.clone(),
+        });
+
+        let tracking = StrategySwitchTracking {
+            tracker,
+            post_actions: upgrades.chain(switches).collect(),
+        };
+
+        let adapt = OrchAdapt {
+            input_size: training.dataset.x_size,
+            loss_recorder: LossRecorder::new(nentities),
+            convergence_tracker,
+            switch_tracking: Some(tracking),
             model_config: model.clone(),
             algorithm_config: training.algorithm.clone(),
         };
@@ -199,7 +267,6 @@ impl Adapter {
                     addr: addr.clone(),
                     spec: worker_spec,
                     partition,
-                    post_action: None,
                 };
 
                 Ok(worker_adapt)
@@ -261,7 +328,6 @@ impl Adapter {
                     addr: addr.clone(),
                     spec: worker_spec,
                     partition,
-                    post_action: None,
                 };
 
                 Ok(worker_adapt)
@@ -289,13 +355,9 @@ impl Adapter {
         model: &ModelConfig,
         training: &TrainingConfig,
         server_addrs: Vec<String>,
-        synchronizer: SynchronizerConfig,
-        store: StoreConfig,
         partitions: Vec<Partition<'a>>,
     ) -> Result<Vec<WorkerAdapt<'a>>> {
         let serializer_spec = self.adapt_serializer(training);
-        let (servers, server_sizes, server_ordering) =
-            self.adapt_servers(model, training, &server_addrs, synchronizer, store)?;
 
         let nworkers = training.worker_addrs.len();
         let trainer_spec = self.adapt_trainer(model, training);
@@ -327,32 +389,20 @@ impl Adapter {
                     seed: training.seed,
                 };
 
-                let post_action = WorkerPostAction::Switch {
-                    server_addrs: server_addrs.clone(),
-                    server_sizes: server_sizes.clone(),
-                    server_ordering: server_ordering.clone(),
-                };
-
                 let worker_adapt = WorkerAdapt {
                     addr: addr.clone(),
                     spec: worker_spec,
                     partition: partition.clone(),
-                    post_action: Some(post_action),
                 };
 
                 Ok(worker_adapt)
             });
 
-        let worker_servers = servers
+        let worker_servers = server_addrs
             .into_iter()
             .zip(&partitions[nworkers..])
             .zip(nworkers..)
-            .map(|((server_adapt, partition), i)| {
-                let ServerAdapt {
-                    addr,
-                    spec: server_spec,
-                } = server_adapt;
-
+            .map(|((addr, partition), i)| {
                 if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
                     let text = format!("failed to resolve {i}'th worker's network address: {addr}");
                     return Err(OrchErr::InvalidConfig(text));
@@ -366,13 +416,10 @@ impl Adapter {
                     seed: training.seed,
                 };
 
-                let post_action = WorkerPostAction::Upgrade { spec: server_spec };
-
                 let worker_adapt = WorkerAdapt {
                     addr: addr.clone(),
                     spec: worker_spec,
                     partition: partition.clone(),
-                    post_action: Some(post_action),
                 };
 
                 Ok(worker_adapt)
@@ -422,7 +469,7 @@ impl Adapter {
         synchronizer: SynchronizerConfig,
         store: StoreConfig,
     ) -> Result<(Vec<ServerAdapt>, Vec<usize>, Vec<usize>)> {
-        let (param_gens, server_sizes, server_ordering) =
+        let (param_gens, server_sizes, server_ordering, _) =
             self.adapt_param_gens(model, training, server_addrs.len())?;
 
         let nworkers = training.worker_addrs.len();
@@ -461,12 +508,27 @@ impl Adapter {
         Ok((servers, server_sizes, server_ordering))
     }
 
+    /// Adapts the parameter generators and partitions the layers to minimize the
+    /// difference in sizes between the servers.
+    ///
+    /// # Args
+    /// * `model` - The model's architecture and initialization configuration.
+    /// * `training` - The training's configuration.
+    /// * `nservers` - The amount of servers.
+    ///
+    /// # Returns
+    /// The param generator specifications, the server sizes, server orderings and the parameter ranges.
     fn adapt_param_gens(
         &self,
         model: &ModelConfig,
         training: &TrainingConfig,
         nservers: usize,
-    ) -> Result<(Vec<ParamGenSpec>, Vec<usize>, Vec<usize>)> {
+    ) -> Result<(
+        Vec<ParamGenSpec>,
+        Vec<usize>,
+        Vec<usize>,
+        Vec<Vec<(usize, usize)>>,
+    )> {
         let (_, param_gens) = self.adapt_layers(model, training.dataset.x_size);
         let nlayers = param_gens.len();
 
@@ -502,7 +564,8 @@ impl Adapter {
         });
 
         let (param_gen_specs, server_sizes) = chained_param_gens.unzip();
-        Ok((param_gen_specs, server_sizes, server_ordering))
+        let ranges = Vec::new();
+        Ok((param_gen_specs, server_sizes, server_ordering, ranges))
     }
 
     /// Adapts a `SynchronizerConfig` into a `SynchronizerSpec`.

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -18,9 +18,10 @@ use super::{
 use crate::{
     configs::{
         ActFnConfig, AlgorithmConfig, DataSrc, DatasetConfig, LayerConfig, LossFnConfig,
-        OptimizerConfig, ParamGenConfig, StoreConfig, SynchronizerConfig,
+        OptimizerConfig, OrchAdapt, ParamGenConfig, StoreConfig, SynchronizerConfig,
     },
     error::{OrchErr, Result},
+    sessions::{ConvergenceTracker, GreaterThanOneUsize, LossRecorder, SwitchTracker},
 };
 
 /// Converts user model and training configurations into worker and server specifications.
@@ -51,7 +52,7 @@ impl Adapter {
         &self,
         model: ModelConfig,
         training: &'a TrainingConfig,
-    ) -> Result<(Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>)> {
+    ) -> Result<(Vec<WorkerAdapt<'a>>, Vec<ServerAdapt>, OrchAdapt)> {
         let partitions =
             self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
 
@@ -97,7 +98,50 @@ impl Adapter {
             }
         };
 
-        Ok((workers, servers))
+        let orch = self.adapt_orch(&model, training)?;
+        Ok((workers, servers, orch))
+    }
+
+    /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerAdapt`.
+    ///
+    /// # Args
+    /// * `model` - The model's configuration.
+    /// * `training` - The training's configuration.
+    ///
+    /// # Returns
+    /// An adapted orchestrator.
+    fn adapt_orch(&self, model: &ModelConfig, training: &TrainingConfig) -> Result<OrchAdapt> {
+        let Some(nworkers) = NonZeroUsize::new(training.worker_addrs.len()) else {
+            let text = "The amount of workers must be positive";
+            return Err(OrchErr::InvalidConfig(text.into()));
+        };
+
+        let convergence_tracker = training.early_stopping.map(|cfg| {
+            // SAFETY: The window size is greater than `1`.
+            let winsize = GreaterThanOneUsize::new(3).unwrap();
+            ConvergenceTracker::new(winsize, cfg.tolerance)
+        });
+
+        let switch_tracker = match training.algorithm {
+            AlgorithmConfig::StrategySwitch { .. } => {
+                // SAFETY: The winsize is greater than `1`.
+                let winsize = GreaterThanOneUsize::new(5).unwrap();
+                let tracker = SwitchTracker::new(winsize, 0.01);
+                Some(tracker)
+            }
+            _ => None,
+        };
+
+        let adapt = OrchAdapt {
+            input_size: training.dataset.x_size,
+            loss_recorder: LossRecorder::new(nworkers),
+            convergence_tracker,
+            switch_tracker,
+            model_config: model.clone(),
+            algorithm_config: training.algorithm.clone(),
+        };
+
+        Ok(adapt)
     }
 
     /// Adapts both `ModelConfig` and `TrainingConfig` into a `WorkerSpec`.
@@ -249,7 +293,7 @@ impl Adapter {
         store: StoreConfig,
         partitions: Vec<Partition<'a>>,
     ) -> Result<Vec<WorkerAdapt<'a>>> {
-        let serializer_spec = self.adapt_serializer(&training);
+        let serializer_spec = self.adapt_serializer(training);
         let (servers, server_sizes, server_ordering) =
             self.adapt_servers(model, training, &server_addrs, synchronizer, store)?;
 
@@ -268,8 +312,8 @@ impl Adapter {
             .worker_addrs
             .iter()
             .zip(&partitions[..nworkers])
-            .enumerate()
-            .map(|(i, (addr, partition))| {
+            .zip(0..)
+            .map(|((addr, partition), i)| {
                 if let Err(..) | Ok(None) = addr.to_socket_addrs().map(|mut addrs| addrs.next()) {
                     let text = format!("failed to resolve {i}'th worker's network address: {addr}");
                     return Err(OrchErr::InvalidConfig(text));
@@ -302,8 +346,8 @@ impl Adapter {
         let worker_servers = servers
             .into_iter()
             .zip(&partitions[nworkers..])
-            .enumerate()
-            .map(|(i, (server_adapt, partition))| {
+            .zip(nworkers..)
+            .map(|((server_adapt, partition), i)| {
                 let ServerAdapt {
                     addr,
                     spec: server_spec,

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -6,7 +6,7 @@ mod validator;
 
 use std::num::NonZeroUsize;
 
-use comms::specs::{server::ServerSpec, worker::WorkerSpec};
+use comms::specs::{machine_learning::TrainerSpec, server::ServerSpec, worker::WorkerSpec};
 
 pub use adapter::Adapter;
 pub use model::{ActFnConfig, LayerConfig, ModelConfig, ParamGenConfig};
@@ -26,6 +26,7 @@ pub enum WorkerPostAction {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     },
     Upgrade {
         spec: ServerSpec,

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -6,6 +6,8 @@ mod validator;
 
 use std::num::NonZeroUsize;
 
+use comms::specs::{server::ServerSpec, worker::WorkerSpec};
+
 pub use adapter::Adapter;
 pub use model::{ActFnConfig, LayerConfig, ModelConfig, ParamGenConfig};
 pub use partition::Partition;
@@ -14,8 +16,6 @@ pub use training::{
     SerializerConfig, StoreConfig, SynchronizerConfig, TrainingConfig,
 };
 pub use validator::Validator;
-
-use comms::specs::{server::ServerSpec, worker::WorkerSpec};
 
 use crate::sessions::{ConvergenceTracker, LossRecorder, SwitchTracker};
 
@@ -29,6 +29,7 @@ pub enum WorkerPostAction {
     },
     Upgrade {
         spec: ServerSpec,
+        ranges: Vec<(usize, usize)>,
     },
 }
 
@@ -38,7 +39,6 @@ pub struct WorkerAdapt<'a> {
     pub addr: String,
     pub spec: WorkerSpec,
     pub partition: Partition<'a>,
-    pub post_action: Option<WorkerPostAction>,
 }
 
 /// The adapted values for server initialization.
@@ -48,13 +48,20 @@ pub struct ServerAdapt {
     pub spec: ServerSpec,
 }
 
+/// The metadata to hold for strategy switching.
+#[derive(Debug)]
+pub struct StrategySwitchTracking {
+    pub tracker: SwitchTracker,
+    pub post_actions: Vec<WorkerPostAction>,
+}
+
 /// The adaptated values for session initialization.
 #[derive(Debug)]
 pub struct OrchAdapt {
     pub input_size: NonZeroUsize,
     pub loss_recorder: LossRecorder,
     pub convergence_tracker: Option<ConvergenceTracker>,
-    pub switch_tracker: Option<SwitchTracker>,
+    pub switch_tracking: Option<StrategySwitchTracking>,
     pub model_config: ModelConfig,
     pub algorithm_config: AlgorithmConfig,
 }

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -12,3 +12,34 @@ pub use training::{
     SerializerConfig, StoreConfig, SynchronizerConfig, TrainingConfig,
 };
 pub use validator::Validator;
+
+use comms::specs::{server::ServerSpec, worker::WorkerSpec};
+
+// TODO: docstring
+#[derive(Debug, Clone)]
+pub enum WorkerPostAction {
+    Switch {
+        server_addrs: Vec<String>,
+        server_sizes: Vec<usize>,
+        server_ordering: Vec<usize>,
+    },
+    Upgrade {
+        spec: ServerSpec,
+    },
+}
+
+/// The result of adapting a worker configuration.
+#[derive(Debug, Clone)]
+pub struct WorkerAdapt<'a> {
+    pub addr: String,
+    pub spec: WorkerSpec,
+    pub partition: Partition<'a>,
+    pub post_action: Option<WorkerPostAction>,
+}
+
+/// The result of adapting a server configuration.
+#[derive(Debug, Clone)]
+pub struct ServerAdapt {
+    pub addr: String,
+    pub spec: ServerSpec,
+}

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -4,6 +4,8 @@ mod partition;
 mod training;
 mod validator;
 
+use std::num::NonZeroUsize;
+
 pub use adapter::Adapter;
 pub use model::{ActFnConfig, LayerConfig, ModelConfig, ParamGenConfig};
 pub use partition::Partition;
@@ -15,7 +17,9 @@ pub use validator::Validator;
 
 use comms::specs::{server::ServerSpec, worker::WorkerSpec};
 
-// TODO: docstring
+use crate::sessions::{ConvergenceTracker, LossRecorder, SwitchTracker};
+
+/// An action taken by the orchestrator based on strategy switch for each worker.
 #[derive(Debug, Clone)]
 pub enum WorkerPostAction {
     Switch {
@@ -28,7 +32,7 @@ pub enum WorkerPostAction {
     },
 }
 
-/// The result of adapting a worker configuration.
+/// The adapted values for worker initialization.
 #[derive(Debug, Clone)]
 pub struct WorkerAdapt<'a> {
     pub addr: String,
@@ -37,9 +41,20 @@ pub struct WorkerAdapt<'a> {
     pub post_action: Option<WorkerPostAction>,
 }
 
-/// The result of adapting a server configuration.
+/// The adapted values for server initialization.
 #[derive(Debug, Clone)]
 pub struct ServerAdapt {
     pub addr: String,
     pub spec: ServerSpec,
+}
+
+/// The adaptated values for session initialization.
+#[derive(Debug)]
+pub struct OrchAdapt {
+    pub input_size: NonZeroUsize,
+    pub loss_recorder: LossRecorder,
+    pub convergence_tracker: Option<ConvergenceTracker>,
+    pub switch_tracker: Option<SwitchTracker>,
+    pub model_config: ModelConfig,
+    pub algorithm_config: AlgorithmConfig,
 }

--- a/orchestrator/src/configs/partition.rs
+++ b/orchestrator/src/configs/partition.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 /// The metadata of a dataset partition.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Partition<'a> {
     Inline {
         samples: &'a [f32],

--- a/orchestrator/src/configs/training.rs
+++ b/orchestrator/src/configs/training.rs
@@ -1,4 +1,8 @@
-use std::{fmt, num::NonZeroUsize, path::PathBuf};
+use std::{
+    fmt::{self, Display, Formatter},
+    num::NonZeroUsize,
+    path::PathBuf,
+};
 
 use comms::floats::{Float01, FloatNonNegative, FloatPositive};
 use serde::{Deserialize, Serialize};
@@ -11,8 +15,8 @@ pub struct EarlyStoppingConfig {
     pub tolerance: FloatNonNegative,
 }
 
-impl fmt::Display for EarlyStoppingConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for EarlyStoppingConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{:.2e}", *self.tolerance)
     }
 }
@@ -93,10 +97,15 @@ pub enum AlgorithmConfig {
         store: StoreConfig,
     },
     AllReduce,
+    StrategySwitch {
+        server_addrs: Vec<String>,
+        synchronizer: SynchronizerConfig,
+        store: StoreConfig,
+    },
 }
 
 /// The `Serializer` configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SerializerConfig {
     #[default]

--- a/orchestrator/src/configs/validator.rs
+++ b/orchestrator/src/configs/validator.rs
@@ -92,12 +92,7 @@ impl Validator {
                     return Err(OrchErr::InvalidConfig(text));
                 }
             }
-            AlgorithmConfig::AllReduce => {
-                if training.worker_addrs.len() < 2 {
-                    let text = "all-reduce requires at least two worker addresses".into();
-                    return Err(OrchErr::InvalidConfig(text));
-                }
-            }
+            _ => {}
         }
 
         let DatasetConfig {

--- a/orchestrator/src/configs/validator.rs
+++ b/orchestrator/src/configs/validator.rs
@@ -85,6 +85,9 @@ impl Validator {
 
         if let AlgorithmConfig::ParameterServer {
             ref server_addrs, ..
+        }
+        | AlgorithmConfig::StrategySwitch {
+            ref server_addrs, ..
         } = training.algorithm
             && server_addrs.is_empty()
         {

--- a/orchestrator/src/configs/validator.rs
+++ b/orchestrator/src/configs/validator.rs
@@ -83,16 +83,13 @@ impl Validator {
             return Err(OrchErr::InvalidConfig(text));
         }
 
-        match training.algorithm {
-            AlgorithmConfig::ParameterServer {
-                ref server_addrs, ..
-            } => {
-                if server_addrs.is_empty() {
-                    let text = "at least one server address is required".into();
-                    return Err(OrchErr::InvalidConfig(text));
-                }
-            }
-            _ => {}
+        if let AlgorithmConfig::ParameterServer {
+            ref server_addrs, ..
+        } = training.algorithm
+            && server_addrs.is_empty()
+        {
+            let text = "at least one server address is required".into();
+            return Err(OrchErr::InvalidConfig(text));
         }
 
         let DatasetConfig {

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -37,7 +37,7 @@ pub fn train(model: ModelConfig, mut training: TrainingConfig) -> Result<Session
     validator.validate(&model, &training)?;
 
     let adapter = Adapter::new();
-    let (workers, servers) = adapter.adapt_configs(model.clone(), &training)?;
+    let (workers, servers, orch) = adapter.adapt_configs(model.clone(), &training)?;
 
     // TODO: De momento lo dejaría acá, no creo que sea muy importante poder
     //       configurar esto, si tenemos tiempo y vemos que viene bien lo
@@ -53,15 +53,7 @@ pub fn train(model: ModelConfig, mut training: TrainingConfig) -> Result<Session
         )
     };
 
-    let session = Session::new(
-        workers,
-        servers,
-        Connector::new(transport_factory),
-        model,
-        training.algorithm.clone(),
-        training.dataset.x_size.get(),
-        training.early_stopping,
-    )?;
+    let session = Session::new(orch, workers, servers, Connector::new(transport_factory))?;
 
     if let Some((samples_bin, labels_bin)) = dataset_bin {
         remove_binary(&samples_bin);

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -37,7 +37,7 @@ pub fn train(model: ModelConfig, mut training: TrainingConfig) -> Result<Session
     validator.validate(&model, &training)?;
 
     let adapter = Adapter::new();
-    let (workers, servers, orch) = adapter.adapt_configs(model.clone(), &training)?;
+    let (orch, workers, servers) = adapter.adapt_configs(model.clone(), &training)?;
 
     // TODO: De momento lo dejaría acá, no creo que sea muy importante poder
     //       configurar esto, si tenemos tiempo y vemos que viene bien lo

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -6,7 +6,8 @@ use std::{
     time::Duration,
 };
 
-use comms::floats::{Float01, FloatNonNegative, FloatPositive};
+use comms::floats::{Float01, FloatPositive};
+use log::info;
 use orchestrator::{CancelHandle, configs::*, train};
 
 const MODEL_OUTPUT_PATH: &str = "model.safetensors";
@@ -62,7 +63,10 @@ fn build_addresses(workers: usize, servers: usize) -> (Vec<String>, Vec<String>)
 }
 
 fn main() -> io::Result<()> {
-    const WORKERS: usize = 3;
+    unsafe { env::set_var("RUST_LOG", "debug") };
+    env_logger::init();
+
+    const WORKERS: usize = 2;
     const SERVERS: usize = 2;
     const RELEASE: bool = false;
 
@@ -70,6 +74,26 @@ fn main() -> io::Result<()> {
 
     thread::sleep(Duration::from_secs(2));
     let (worker_addrs, server_addrs) = build_addresses(WORKERS, SERVERS);
+
+    let synchronizer_config = SynchronizerConfig::NonBlocking;
+    let store_config = StoreConfig::Wild;
+
+    #[allow(unused_variables)]
+    let parameter_server_config = AlgorithmConfig::ParameterServer {
+        server_addrs: server_addrs.clone(),
+        synchronizer: synchronizer_config,
+        store: store_config,
+    };
+
+    #[allow(unused_variables)]
+    let all_reduce_config = AlgorithmConfig::AllReduce;
+
+    #[allow(unused_variables)]
+    let strategy_switch_config = AlgorithmConfig::StrategySwitch {
+        server_addrs,
+        synchronizer: synchronizer_config,
+        store: store_config,
+    };
 
     let model_config = ModelConfig {
         layers: vec![
@@ -97,19 +121,9 @@ fn main() -> io::Result<()> {
         ],
     };
 
-    let algorithm_config = if !server_addrs.is_empty() {
-        AlgorithmConfig::ParameterServer {
-            server_addrs,
-            synchronizer: SynchronizerConfig::NonBlocking,
-            store: StoreConfig::Wild,
-        }
-    } else {
-        AlgorithmConfig::AllReduce
-    };
-
     let training_config = TrainingConfig {
         worker_addrs,
-        algorithm: algorithm_config,
+        algorithm: strategy_switch_config,
         serializer: SerializerConfig::SparseCapable {
             r: Float01::new(0.9).unwrap(),
         },
@@ -164,13 +178,10 @@ fn main() -> io::Result<()> {
         },
         loss_fn: LossFnConfig::Mse,
         batch_size: NonZeroUsize::new(4).unwrap(),
-        max_epochs: NonZeroUsize::new(1000).unwrap(),
+        max_epochs: NonZeroUsize::new(100).unwrap(),
         offline_epochs: 0,
         seed: Some(42),
-        // early_stopping: None,
-        early_stopping: Some(EarlyStoppingConfig {
-            tolerance: FloatNonNegative::new(0.5).unwrap(),
-        }),
+        early_stopping: None,
     };
 
     let session = train(model_config, training_config).unwrap();
@@ -180,24 +191,24 @@ fn main() -> io::Result<()> {
     loop {
         match rx.blocking_recv() {
             Some(orchestrator::TrainingEvent::PublishedLosses { losses, worker_id }) => {
-                println!("losses {worker_id}: {losses:?}")
+                info!("losses: {worker_id}: {losses:?}");
             }
             Some(orchestrator::TrainingEvent::TrainingComplete {
                 model: trained,
                 stop_reason: reason,
             }) => {
-                println!("params: {:?}", trained.params);
-                println!("stop reason: {reason:?}");
+                info!("params: {:?}", trained.params);
+                info!("stop reason: {reason:?}");
 
                 trained
                     .save_safetensors(MODEL_OUTPUT_PATH)
                     .expect("failed to save model");
 
-                println!("saved model to {MODEL_OUTPUT_PATH}");
+                info!("saved model to {MODEL_OUTPUT_PATH}");
                 break;
             }
             None => break,
-            res => println!("result: {res:?}"),
+            res => info!("result: {res:?}"),
         }
     }
 

--- a/orchestrator/src/sessions/cancel_handle.rs
+++ b/orchestrator/src/sessions/cancel_handle.rs
@@ -1,0 +1,21 @@
+use tokio::sync::mpsc::{self, Receiver, Sender};
+
+/// A handle that lets any caller request an early stop of an ongoing training session.
+pub struct CancelHandle(Sender<()>);
+
+impl CancelHandle {
+    /// Creates a matched `(CancelHandle, Receiver)` pair.
+    ///
+    /// The caller retains the `CancelHandle` and passes the `Receiver` to
+    /// `Session::event_listener`. Calling `stop()` on the handle signals
+    /// the session to stop at the next epoch boundary.
+    pub fn pair() -> (Self, Receiver<()>) {
+        let (tx, rx) = mpsc::channel(1);
+        (Self(tx), rx)
+    }
+
+    /// Sends a cancel signal to the receiver.
+    pub fn stop(&self) {
+        let _ = self.0.try_send(());
+    }
+}

--- a/orchestrator/src/sessions/convergence_tracker.rs
+++ b/orchestrator/src/sessions/convergence_tracker.rs
@@ -1,60 +1,56 @@
-use std::{collections::HashMap, mem};
+use comms::floats::FloatNonNegative;
+
+use super::GreaterThanOneUsize;
 
 /// Tracks wheather the training is converging or not.
+#[derive(Debug)]
 pub struct ConvergenceTracker {
-    pending: HashMap<usize, f64>,
-    prev: HashMap<usize, f64>,
-    n_workers: usize,
+    winsize: GreaterThanOneUsize,
+    tolerance: FloatNonNegative,
+    last: Option<f64>,
+    count: usize,
 }
 
 impl ConvergenceTracker {
     /// Creates a new `ConvergenceTracker`.
     ///
     /// # Args
-    /// * `n_workers` - The amount of workers
+    /// * `winsize` - The amount of losses to check.
+    /// * `tolerance` - The tolerance of the delta between subsequent losses.
     ///
     /// # Returns
     /// A new `ConvergenceTracker` instance.
-    pub fn new(n_workers: usize) -> Self {
+    pub fn new(winsize: GreaterThanOneUsize, tolerance: FloatNonNegative) -> Self {
         Self {
-            n_workers,
-            pending: HashMap::new(),
-            prev: HashMap::new(),
+            winsize,
+            tolerance,
+            last: None,
+            count: 0,
         }
     }
 
-    /// Records the last loss for a worker and returns the max per-worker delta
-    /// once all workers have reported for the current sync round.
+    /// Records a new loss.
     ///
     /// # Args
-    /// * `worker_id` - The id of the worker whose losses are being recorded.
-    /// * `losses` - The losses to record.
-    ///
-    /// # Returns
-    /// The max delta across all workers, or `None` if not all workers have
-    /// reported yet or if this is the first complete round.
-    pub fn record(&mut self, worker_id: usize, losses: &[f64]) -> Option<f64> {
-        let last = *losses.last()?;
-        self.pending.insert(worker_id, last);
+    /// * `loss` - The latest loss.
+    pub fn record(&mut self, loss: f64) {
+        if let Some(last) = self.last {
+            let delta = (last - loss).abs();
 
-        if self.pending.len() < self.n_workers {
-            return None;
+            if delta > *self.tolerance {
+                self.count = 0;
+            }
         }
 
-        let max_delta = if self.prev.len() == self.n_workers {
-            self.pending
-                .iter()
-                .filter_map(|(id, &curr)| self.prev.get(id).map(|&prev| (prev - curr).abs()))
-                .fold(0.0, f64::max)
-        } else {
-            mem::swap(&mut self.prev, &mut self.pending);
-            self.pending.clear();
-            return None;
-        };
+        self.count += 1;
+        self.last = Some(loss);
+    }
 
-        std::mem::swap(&mut self.prev, &mut self.pending);
-        self.pending.clear();
-
-        Some(max_delta)
+    /// Asks the tracker if the training has converged.
+    ///
+    /// # Returns
+    /// A convergence flag, either `true` if the training converged or `false` otherwise.
+    pub fn converged(&self) -> bool {
+        *self.winsize + 1 == self.count
     }
 }

--- a/orchestrator/src/sessions/convergence_tracker.rs
+++ b/orchestrator/src/sessions/convergence_tracker.rs
@@ -51,6 +51,6 @@ impl ConvergenceTracker {
     /// # Returns
     /// A convergence flag, either `true` if the training converged or `false` otherwise.
     pub fn converged(&self) -> bool {
-        *self.winsize + 1 == self.count
+        self.count == *self.winsize
     }
 }

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -3,22 +3,23 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::{
     StopReason, TrainingEvent,
-    configs::{EarlyStoppingConfig, WorkerPostAction},
-    sessions::{ConvergenceTracker, WorkerRequest},
+    configs::WorkerPostAction,
+    sessions::{ConvergenceTracker, LossRecorder, SwitchTracker, WorkerRequest},
 };
 
 /// The main loop over the training events in the system.
 pub struct EventListener<'a> {
     cancel_rx: Receiver<()>,
     req_txs: &'a mut [Sender<WorkerRequest>],
-    early_stopping: Option<EarlyStoppingConfig>,
     event_rx: &'a mut Receiver<TrainingEvent>,
     event_tx: Sender<TrainingEvent>,
     worker_post_actions: Option<Vec<WorkerPostAction>>,
+    switch_tracker: Option<SwitchTracker>,
 
     // Training state
     workers_left: usize,
-    tracker: ConvergenceTracker,
+    loss_recorder: LossRecorder,
+    convergence_tracker: Option<ConvergenceTracker>,
     stop_reason: Option<StopReason>,
 }
 
@@ -28,32 +29,38 @@ impl<'a> EventListener<'a> {
     /// # Args
     /// * `cancel_rx` - The training cancellation request receiver.
     /// * `req_txs` - The request senders for the worker listeners.
-    /// * `early_stopping` - The early stopping mechanism.
+    /// * `loss_recorder` - The workers' loss recorder.
+    /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `event_rx` - An event producer.
     /// * `event_tx` - An event consumer.
     /// * `worker_post_actions` - The actions to take per worker for strategy switch.
+    /// * `switch_tracker` - The tracker needed for strategy switch triggering.
     ///
     /// # Returns
     /// A new `EventListener` instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cancel_rx: Receiver<()>,
         req_txs: &'a mut [Sender<WorkerRequest>],
-        early_stopping: Option<EarlyStoppingConfig>,
+        loss_recorder: LossRecorder,
+        convergence_tracker: Option<ConvergenceTracker>,
         event_rx: &'a mut Receiver<TrainingEvent>,
         event_tx: Sender<TrainingEvent>,
         worker_post_actions: Option<Vec<WorkerPostAction>>,
+        switch_tracker: Option<SwitchTracker>,
     ) -> Self {
-        let n_workers = req_txs.len();
+        let nworkers = req_txs.len();
 
         Self {
             cancel_rx,
             req_txs,
-            early_stopping,
+            loss_recorder,
+            convergence_tracker,
             event_rx,
             event_tx,
             worker_post_actions,
-            workers_left: n_workers,
-            tracker: ConvergenceTracker::new(n_workers),
+            switch_tracker,
+            workers_left: nworkers,
             stop_reason: None,
         }
     }
@@ -112,18 +119,7 @@ impl<'a> EventListener<'a> {
                 Some(self.workers_left > 0)
             }
             TrainingEvent::PublishedLosses { worker_id, losses } => {
-                // TODO: Chequear aca si se cumple la condicion para hacer la transicion de strategy switch
-
-                if self.stop_reason.is_none()
-                    && let Some(ref cfg) = self.early_stopping
-                    && let Some(max_delta) = self.tracker.record(worker_id, &losses)
-                    && max_delta < *cfg.tolerance as f64
-                {
-                    info!("early stopping triggered (max_delta={max_delta:.6})");
-                    self.stop_reason = Some(StopReason::EarlyStopping);
-                    self.broadcast_request(WorkerRequest::Stop).await;
-                }
-
+                self.handle_losses(worker_id, &losses).await;
                 let event = TrainingEvent::PublishedLosses { worker_id, losses };
                 let _ = self.event_tx.send(event).await;
                 Some(true)
@@ -132,6 +128,49 @@ impl<'a> EventListener<'a> {
                 let is_err = matches!(other, TrainingEvent::Error(..));
                 let _ = self.event_tx.send(other).await;
                 (!is_err).then_some(true)
+            }
+        }
+    }
+
+    /// Handles the latest loss update from a worker.
+    ///
+    /// # Args
+    /// * `worker_id` - The id of the worker whose losses are being processed.
+    /// * `losses` - The losses it published.
+    async fn handle_losses(&mut self, worker_id: usize, losses: &[f64]) {
+        if self.stop_reason.is_some() {
+            return;
+        }
+
+        if let Some(&last) = losses.last() {
+            self.loss_recorder.record(worker_id, last);
+        }
+
+        let Some(loss) = self.loss_recorder.max() else {
+            return;
+        };
+
+        self.loss_recorder.clear();
+
+        if let Some(ref mut tracker) = self.convergence_tracker {
+            tracker.record(loss);
+
+            if tracker.converged() {
+                info!("early stopping triggered");
+                self.stop_reason = Some(StopReason::EarlyStopping);
+                self.broadcast_request(WorkerRequest::Stop).await;
+                return;
+            }
+        }
+
+        if let Some(ref mut tracker) = self.switch_tracker {
+            tracker.record(loss);
+
+            if tracker.should_switch() {
+                info!("strategy switch triggered");
+
+                // TODO: Implementar el switch.
+                todo!("implement the strategy switch");
             }
         }
     }

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::{
     StopReason, TrainingEvent,
-    configs::EarlyStoppingConfig,
+    configs::{EarlyStoppingConfig, WorkerPostAction},
     sessions::{ConvergenceTracker, WorkerRequest},
 };
 
@@ -14,6 +14,7 @@ pub struct EventListener<'a> {
     early_stopping: Option<EarlyStoppingConfig>,
     event_rx: &'a mut Receiver<TrainingEvent>,
     event_tx: Sender<TrainingEvent>,
+    worker_post_actions: Option<Vec<WorkerPostAction>>,
 
     // Training state
     workers_left: usize,
@@ -30,6 +31,7 @@ impl<'a> EventListener<'a> {
     /// * `early_stopping` - The early stopping mechanism.
     /// * `event_rx` - An event producer.
     /// * `event_tx` - An event consumer.
+    /// * `worker_post_actions` - The actions to take per worker for strategy switch.
     ///
     /// # Returns
     /// A new `EventListener` instance.
@@ -39,6 +41,7 @@ impl<'a> EventListener<'a> {
         early_stopping: Option<EarlyStoppingConfig>,
         event_rx: &'a mut Receiver<TrainingEvent>,
         event_tx: Sender<TrainingEvent>,
+        worker_post_actions: Option<Vec<WorkerPostAction>>,
     ) -> Self {
         let n_workers = req_txs.len();
 
@@ -48,6 +51,7 @@ impl<'a> EventListener<'a> {
             early_stopping,
             event_rx,
             event_tx,
+            worker_post_actions,
             workers_left: n_workers,
             tracker: ConvergenceTracker::new(n_workers),
             stop_reason: None,
@@ -108,6 +112,8 @@ impl<'a> EventListener<'a> {
                 Some(self.workers_left > 0)
             }
             TrainingEvent::PublishedLosses { worker_id, losses } => {
+                // TODO: Chequear aca si se cumple la condicion para hacer la transicion de strategy switch
+
                 if self.stop_reason.is_none()
                     && let Some(ref cfg) = self.early_stopping
                     && let Some((prev, curr)) = self.tracker.record(worker_id, &losses)

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -180,7 +180,7 @@ impl<'a> EventListener<'a> {
     /// Broadcasts the `WorkerPostActions` to all the workers.
     ///
     /// # Args
-    /// * `post_actios` - The action that each worker needs to take in order to switch algorithm.
+    /// * `post_actions` - The action that each worker needs to take in order to switch algorithm.
     async fn broadcast_switch(&mut self, post_actions: Vec<WorkerPostAction>) {
         for (tx, action) in self.req_txs.iter_mut().zip(post_actions) {
             let req = match action {

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -1,10 +1,12 @@
+use std::mem;
+
 use log::info;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::{
     StopReason, TrainingEvent,
-    configs::WorkerPostAction,
-    sessions::{ConvergenceTracker, LossRecorder, SwitchTracker, WorkerRequest},
+    configs::{StrategySwitchTracking, WorkerPostAction},
+    sessions::{ConvergenceTracker, LossRecorder, WorkerRequest},
 };
 
 /// The main loop over the training events in the system.
@@ -13,12 +15,11 @@ pub struct EventListener<'a> {
     req_txs: &'a mut [Sender<WorkerRequest>],
     event_rx: &'a mut Receiver<TrainingEvent>,
     event_tx: Sender<TrainingEvent>,
-    worker_post_actions: Option<Vec<WorkerPostAction>>,
-    switch_tracker: Option<SwitchTracker>,
 
     // Training state
     workers_left: usize,
     loss_recorder: LossRecorder,
+    switch_tracking: Option<StrategySwitchTracking>,
     convergence_tracker: Option<ConvergenceTracker>,
     stop_reason: Option<StopReason>,
 }
@@ -33,8 +34,7 @@ impl<'a> EventListener<'a> {
     /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `event_rx` - An event producer.
     /// * `event_tx` - An event consumer.
-    /// * `worker_post_actions` - The actions to take per worker for strategy switch.
-    /// * `switch_tracker` - The tracker needed for strategy switch triggering.
+    /// * `switch_tracking` - The strategy switch tracking metadata.
     ///
     /// # Returns
     /// A new `EventListener` instance.
@@ -46,8 +46,7 @@ impl<'a> EventListener<'a> {
         convergence_tracker: Option<ConvergenceTracker>,
         event_rx: &'a mut Receiver<TrainingEvent>,
         event_tx: Sender<TrainingEvent>,
-        worker_post_actions: Option<Vec<WorkerPostAction>>,
-        switch_tracker: Option<SwitchTracker>,
+        switch_tracking: Option<StrategySwitchTracking>,
     ) -> Self {
         let nworkers = req_txs.len();
 
@@ -58,8 +57,7 @@ impl<'a> EventListener<'a> {
             convergence_tracker,
             event_rx,
             event_tx,
-            worker_post_actions,
-            switch_tracker,
+            switch_tracking,
             workers_left: nworkers,
             stop_reason: None,
         }
@@ -94,16 +92,6 @@ impl<'a> EventListener<'a> {
         Some(self.stop_reason.unwrap_or_default())
     }
 
-    /// Broadcasts a single request to all of the request senders.
-    ///
-    /// # Args
-    /// * `req` - The request to broadcast.
-    async fn broadcast_request(&mut self, req: WorkerRequest) {
-        for tx in self.req_txs.iter_mut() {
-            let _ = tx.send(req).await;
-        }
-    }
-
     /// Handles an incoming event from a worker.
     ///
     /// # Args
@@ -123,6 +111,12 @@ impl<'a> EventListener<'a> {
                 let event = TrainingEvent::PublishedLosses { worker_id, losses };
                 let _ = self.event_tx.send(event).await;
                 Some(true)
+            }
+            TrainingEvent::Upgrade { server_handle } => {
+                // TODO: Ver como reincorporar este handle a la session, capaz lo que conviene
+                //       es que los handles de server los tenga este listener y despues se los
+                //       devuelva a la session una vez que termina el entrenamiento?.
+                todo!();
             }
             other => {
                 let is_err = matches!(other, TrainingEvent::Error(..));
@@ -163,15 +157,55 @@ impl<'a> EventListener<'a> {
             }
         }
 
-        if let Some(ref mut tracker) = self.switch_tracker {
+        if let Some(ref mut switch_tracking) = self.switch_tracking {
+            let StrategySwitchTracking {
+                tracker,
+                post_actions,
+            } = switch_tracking;
+
             tracker.record(loss);
 
             if tracker.should_switch() {
                 info!("strategy switch triggered");
-
-                // TODO: Implementar el switch.
-                todo!("implement the strategy switch");
+                let taken = mem::take(post_actions);
+                self.broadcast_switch(taken).await;
+                self.switch_tracking = None;
             }
+        }
+    }
+
+    /// Broadcasts the `WorkerPostActions` to all the workers.
+    ///
+    /// # Args
+    /// * `post_actios` - The action that each worker needs to take in order to switch algorithm.
+    async fn broadcast_switch(&mut self, post_actions: Vec<WorkerPostAction>) {
+        for (tx, action) in self.req_txs.iter_mut().zip(post_actions) {
+            let req = match action {
+                WorkerPostAction::Switch {
+                    server_addrs,
+                    server_sizes,
+                    server_ordering,
+                } => WorkerRequest::Switch {
+                    server_addrs,
+                    server_sizes,
+                    server_ordering,
+                },
+                WorkerPostAction::Upgrade { spec, ranges } => {
+                    WorkerRequest::Upgrade { spec, ranges }
+                }
+            };
+
+            let _ = tx.send(req).await;
+        }
+    }
+
+    /// Broadcasts a single request to all of the request senders.
+    ///
+    /// # Args
+    /// * `req` - The request to broadcast.
+    async fn broadcast_request(&mut self, req: WorkerRequest) {
+        for tx in self.req_txs.iter_mut() {
+            let _ = tx.send(req.clone()).await;
         }
     }
 }

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -187,10 +187,12 @@ impl<'a> EventListener<'a> {
                     server_addrs,
                     server_sizes,
                     server_ordering,
+                    trainer_spec,
                 } => WorkerRequest::Switch {
                     server_addrs,
                     server_sizes,
                     server_ordering,
+                    trainer_spec,
                 },
                 WorkerPostAction::Upgrade { spec, ranges } => WorkerRequest::Upgrade {
                     spec: Box::new(spec),

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -193,7 +193,7 @@ impl<'a> EventListener<'a> {
                     server_addrs,
                     server_sizes,
                     server_ordering,
-                    trainer_spec,
+                    trainer_spec: Box::new(trainer_spec),
                 },
                 WorkerPostAction::Upgrade { spec, ranges } => WorkerRequest::Upgrade {
                     spec: Box::new(spec),

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -118,6 +118,7 @@ impl<'a> EventListener<'a> {
             }
             TrainingEvent::Upgrade { server_handle } => {
                 self.server_handles.push(*server_handle);
+                self.workers_left = self.workers_left.saturating_sub(1);
                 Some(true)
             }
             other => {

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use comms::{NetRtp, ParamServerHandle};
 use log::info;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -12,6 +13,7 @@ use crate::{
 /// The main loop over the training events in the system.
 pub struct EventListener<'a> {
     cancel_rx: Receiver<()>,
+    server_handles: &'a mut Vec<ParamServerHandle<NetRtp>>,
     req_txs: &'a mut [Sender<WorkerRequest>],
     event_rx: &'a mut Receiver<TrainingEvent>,
     event_tx: Sender<TrainingEvent>,
@@ -30,6 +32,7 @@ impl<'a> EventListener<'a> {
     /// # Args
     /// * `cancel_rx` - The training cancellation request receiver.
     /// * `req_txs` - The request senders for the worker listeners.
+    /// * `server_handles` - The server handles session vec.
     /// * `loss_recorder` - The workers' loss recorder.
     /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `event_rx` - An event producer.
@@ -41,6 +44,7 @@ impl<'a> EventListener<'a> {
     pub fn new(
         cancel_rx: Receiver<()>,
         req_txs: &'a mut [Sender<WorkerRequest>],
+        server_handles: &'a mut Vec<ParamServerHandle<NetRtp>>,
         loss_recorder: LossRecorder,
         convergence_tracker: Option<ConvergenceTracker>,
         event_rx: &'a mut Receiver<TrainingEvent>,
@@ -51,6 +55,7 @@ impl<'a> EventListener<'a> {
 
         Self {
             cancel_rx,
+            server_handles,
             req_txs,
             loss_recorder,
             convergence_tracker,
@@ -111,12 +116,9 @@ impl<'a> EventListener<'a> {
                 let _ = self.event_tx.send(event).await;
                 Some(true)
             }
-            #[allow(unused_variables)]
             TrainingEvent::Upgrade { server_handle } => {
-                // TODO: Ver como reincorporar este handle a la session, capaz lo que conviene
-                //       es que los handles de server los tenga este listener y despues se los
-                //       devuelva a la session una vez que termina el entrenamiento?.
-                todo!();
+                self.server_handles.push(*server_handle);
+                Some(true)
             }
             other => {
                 let is_err = matches!(other, TrainingEvent::Error(..));

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -38,7 +38,6 @@ impl<'a> EventListener<'a> {
     ///
     /// # Returns
     /// A new `EventListener` instance.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cancel_rx: Receiver<()>,
         req_txs: &'a mut [Sender<WorkerRequest>],
@@ -112,6 +111,7 @@ impl<'a> EventListener<'a> {
                 let _ = self.event_tx.send(event).await;
                 Some(true)
             }
+            #[allow(unused_variables)]
             TrainingEvent::Upgrade { server_handle } => {
                 // TODO: Ver como reincorporar este handle a la session, capaz lo que conviene
                 //       es que los handles de server los tenga este listener y despues se los
@@ -190,9 +190,10 @@ impl<'a> EventListener<'a> {
                     server_sizes,
                     server_ordering,
                 },
-                WorkerPostAction::Upgrade { spec, ranges } => {
-                    WorkerRequest::Upgrade { spec, ranges }
-                }
+                WorkerPostAction::Upgrade { spec, ranges } => WorkerRequest::Upgrade {
+                    spec: Box::new(spec),
+                    ranges,
+                },
             };
 
             let _ = tx.send(req).await;

--- a/orchestrator/src/sessions/greater_than_one_usize.rs
+++ b/orchestrator/src/sessions/greater_than_one_usize.rs
@@ -1,0 +1,29 @@
+use std::ops::Deref;
+
+/// A usize that must be greater than `1`.
+#[derive(Debug, Clone, Copy)]
+pub struct GreaterThanOneUsize {
+    n: usize,
+}
+
+impl GreaterThanOneUsize {
+    /// Creates a new `GreaterThanOneUsize`.
+    ///
+    /// # Args
+    /// * `n` - The inner value.
+    ///
+    /// # Returns
+    /// A new `GreaterThanOneUsize` instance if the given
+    /// value is greater than `1`. `None` otherwise.
+    pub fn new(n: usize) -> Option<Self> {
+        (n > 1).then_some(Self { n })
+    }
+}
+
+impl Deref for GreaterThanOneUsize {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.n
+    }
+}

--- a/orchestrator/src/sessions/loss_recorder.rs
+++ b/orchestrator/src/sessions/loss_recorder.rs
@@ -32,7 +32,9 @@ impl LossRecorder {
     /// * `worker_id` - The id of the worker whose loss is being recorded.
     /// * `loss` - The latest loss.
     pub fn record(&mut self, worker_id: usize, loss: f64) {
-        self.losses.insert(worker_id);
+        if !self.losses.insert(worker_id) {
+            return;
+        }
         self.max_loss = self.max_loss.max(loss);
         self.sum_loss += loss;
     }

--- a/orchestrator/src/sessions/loss_recorder.rs
+++ b/orchestrator/src/sessions/loss_recorder.rs
@@ -1,0 +1,77 @@
+use std::{collections::HashSet, num::NonZeroUsize};
+
+/// Records statistics of the worker losses.
+#[derive(Debug)]
+pub struct LossRecorder {
+    losses: HashSet<usize>,
+    max_loss: f64,
+    sum_loss: f64,
+    n: NonZeroUsize,
+}
+
+impl LossRecorder {
+    /// Creates a new `LossRecorder`.
+    ///
+    /// # Args
+    /// * `n` - The amount of worker losses to track simultaneously.
+    ///
+    /// # Returns
+    /// A new `LossRecorder` instance.
+    pub fn new(n: NonZeroUsize) -> Self {
+        Self {
+            losses: HashSet::with_capacity(n.get()),
+            max_loss: 0.0,
+            sum_loss: 0.0,
+            n,
+        }
+    }
+
+    /// Records a new loss for a worker.
+    ///
+    /// # Args
+    /// * `worker_id` - The id of the worker whose loss is being recorded.
+    /// * `loss` - The latest loss.
+    pub fn record(&mut self, worker_id: usize, loss: f64) {
+        self.losses.insert(worker_id);
+        self.max_loss = self.max_loss.max(loss);
+        self.sum_loss += loss;
+    }
+
+    /// Gets the max loss of all the workers.
+    ///
+    /// # Returns
+    /// Either `Some(loss)` or `None` if not all workers have recorded losses.
+    pub fn max(&self) -> Option<f64> {
+        self.stat_if_full(|| self.max_loss)
+    }
+
+    /// Gets the mean loss of all the workers.
+    ///
+    /// # Returns
+    /// Either `Some(loss)` or `None` if not all workers have recorded losses.
+    pub fn mean(&self) -> Option<f64> {
+        self.stat_if_full(|| self.sum_loss / self.n.get() as f64)
+    }
+
+    /// Clears the inner state for the following recording.
+    pub fn clear(&mut self) {
+        self.losses.clear();
+        self.max_loss = 0.0;
+        self.sum_loss = 0.0;
+    }
+
+    /// Gets the statistic if the record is filled with all the workers' losses.
+    ///
+    /// # Returns
+    /// Either `Some(loss)` or `None` if nont all workers have recorded losses.
+    fn stat_if_full<F>(&self, f: F) -> Option<f64>
+    where
+        F: FnOnce() -> f64,
+    {
+        if self.losses.len() == self.n.get() {
+            Some(f())
+        } else {
+            None
+        }
+    }
+}

--- a/orchestrator/src/sessions/mod.rs
+++ b/orchestrator/src/sessions/mod.rs
@@ -33,7 +33,7 @@ pub enum WorkerRequest {
         server_ordering: Vec<usize>,
     },
     Upgrade {
-        spec: ServerSpec,
+        spec: Box<ServerSpec>,
         ranges: Vec<(usize, usize)>,
     },
     Stop,
@@ -56,7 +56,7 @@ pub enum TrainingEvent {
         worker_id: usize,
     },
     Upgrade {
-        server_handle: ParamServerHandle<NetRtp>,
+        server_handle: Box<ParamServerHandle<NetRtp>>,
     },
     Error(OrchErr),
 }

--- a/orchestrator/src/sessions/mod.rs
+++ b/orchestrator/src/sessions/mod.rs
@@ -8,7 +8,10 @@ mod switch_tracker;
 mod trained_model;
 mod worker_listener;
 
-use comms::{NetRtp, ParamServerHandle, specs::server::ServerSpec};
+use comms::{
+    NetRtp, ParamServerHandle,
+    specs::{machine_learning::TrainerSpec, server::ServerSpec},
+};
 
 pub use cancel_handle::CancelHandle;
 pub use convergence_tracker::ConvergenceTracker;
@@ -31,6 +34,7 @@ pub enum WorkerRequest {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     },
     Upgrade {
         spec: Box<ServerSpec>,

--- a/orchestrator/src/sessions/mod.rs
+++ b/orchestrator/src/sessions/mod.rs
@@ -34,7 +34,7 @@ pub enum WorkerRequest {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
-        trainer_spec: TrainerSpec,
+        trainer_spec: Box<TrainerSpec>,
     },
     Upgrade {
         spec: Box<ServerSpec>,

--- a/orchestrator/src/sessions/mod.rs
+++ b/orchestrator/src/sessions/mod.rs
@@ -8,6 +8,8 @@ mod switch_tracker;
 mod trained_model;
 mod worker_listener;
 
+use comms::{NetRtp, ParamServerHandle, specs::server::ServerSpec};
+
 pub use cancel_handle::CancelHandle;
 pub use convergence_tracker::ConvergenceTracker;
 pub use event_listener::EventListener;
@@ -21,10 +23,19 @@ pub use worker_listener::WorkerListener;
 use crate::OrchErr;
 
 /// Requests that the orchestrator can make to a worker handler task.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum WorkerRequest {
     PullParams,
     Disconnect,
+    Switch {
+        server_addrs: Vec<String>,
+        server_sizes: Vec<usize>,
+        server_ordering: Vec<usize>,
+    },
+    Upgrade {
+        spec: ServerSpec,
+        ranges: Vec<(usize, usize)>,
+    },
     Stop,
 }
 
@@ -43,6 +54,9 @@ pub enum TrainingEvent {
     Params(Vec<f32>),
     Disconnect {
         worker_id: usize,
+    },
+    Upgrade {
+        server_handle: ParamServerHandle<NetRtp>,
     },
     Error(OrchErr),
 }

--- a/orchestrator/src/sessions/mod.rs
+++ b/orchestrator/src/sessions/mod.rs
@@ -1,12 +1,20 @@
+mod cancel_handle;
 mod convergence_tracker;
 mod event_listener;
+mod greater_than_one_usize;
+mod loss_recorder;
 mod session;
+mod switch_tracker;
 mod trained_model;
 mod worker_listener;
 
+pub use cancel_handle::CancelHandle;
 pub use convergence_tracker::ConvergenceTracker;
 pub use event_listener::EventListener;
-pub use session::{CancelHandle, Session};
+pub use greater_than_one_usize::GreaterThanOneUsize;
+pub use loss_recorder::LossRecorder;
+pub use session::Session;
+pub use switch_tracker::SwitchTracker;
 pub use trained_model::TrainedModel;
 pub use worker_listener::WorkerListener;
 

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -22,7 +22,10 @@ use tokio::{
 use super::TrainedModel;
 use crate::{
     OrchErr, Result, StopReason, TrainingEvent,
-    configs::{AlgorithmConfig, EarlyStoppingConfig, ModelConfig, Partition},
+    configs::{
+        AlgorithmConfig, EarlyStoppingConfig, ModelConfig, Partition, ServerAdapt, WorkerAdapt,
+        WorkerPostAction,
+    },
     sessions::{EventListener, WorkerListener, WorkerRequest},
 };
 
@@ -50,6 +53,7 @@ pub struct Session {
     runtime: Runtime,
     worker_handles: Vec<WorkerHandle<NetRtp>>,
     server_handles: Vec<ParamServerHandle<NetRtp>>,
+    worker_post_actions: Option<Vec<WorkerPostAction>>,
     model: ModelConfig,
     algorithm: AlgorithmConfig,
     input_size: usize,
@@ -73,8 +77,8 @@ impl Session {
     /// # Errors
     /// Returns an `OrchErr` if any connection or bootstrap message fails.
     pub fn new<F>(
-        workers: Vec<(String, WorkerSpec, Partition<'_>)>,
-        servers: Vec<(String, ServerSpec)>,
+        workers: Vec<WorkerAdapt<'_>>,
+        servers: Vec<ServerAdapt>,
         connector: Connector<OwnedReadHalf, OwnedWriteHalf, NetRtp, F>,
         model: ModelConfig,
         algorithm: AlgorithmConfig,
@@ -89,16 +93,33 @@ impl Session {
 
         let server_handles = match algorithm {
             AlgorithmConfig::ParameterServer { .. } => {
+                let servers_create = servers
+                    .into_iter()
+                    .map(|ServerAdapt { addr, spec }| (addr, spec));
+
                 info!("connecting to {nservers} servers");
-                let server_handles = runtime.block_on(Self::create_servers(servers, &connector))?;
+                let server_handles =
+                    runtime.block_on(Self::create_servers(servers_create, &connector))?;
                 info!("successfully created servers");
                 server_handles
             }
             _ => Vec::new(),
         };
 
+        let (workers_create, worker_post_actions): (Vec<_>, Vec<_>) = workers
+            .into_iter()
+            .map(
+                |WorkerAdapt {
+                     addr,
+                     spec,
+                     partition,
+                     post_action,
+                 }| ((addr, spec, partition), post_action),
+            )
+            .unzip();
+
         info!("connecting to {nworkers} workers");
-        let worker_handles = runtime.block_on(Self::create_workers(workers, &connector))?;
+        let worker_handles = runtime.block_on(Self::create_workers(workers_create, &connector))?;
         info!("successfully created workers");
 
         Ok(Self {
@@ -109,6 +130,7 @@ impl Session {
             algorithm,
             input_size,
             early_stopping,
+            worker_post_actions: worker_post_actions.into_iter().collect(),
         })
     }
 
@@ -134,6 +156,7 @@ impl Session {
             algorithm,
             input_size,
             early_stopping,
+            worker_post_actions,
         } = self;
 
         let run_loop_fut = async move {
@@ -146,6 +169,7 @@ impl Session {
                 cancel_rx,
                 early_stopping,
                 &user_event_tx,
+                worker_post_actions,
             )
             .await
             else {
@@ -191,6 +215,7 @@ impl Session {
     /// * `cancel_rx` - The user's halt event receiver.
     /// * `early_stopping` - The early stopping mechanism configuration.
     /// * `user_event_tx` - The user event producer.
+    /// * `worker_post_actions` - The actions to take per worker for strategy switch.
     ///
     /// # Returns
     /// The worker listener requesters and the stopping reason for the training.
@@ -201,6 +226,7 @@ impl Session {
         cancel_rx: Receiver<()>,
         early_stopping: Option<EarlyStoppingConfig>,
         user_event_tx: &Sender<TrainingEvent>,
+        worker_post_actions: Option<Vec<WorkerPostAction>>,
     ) -> (Option<StopReason>, Vec<Sender<WorkerRequest>>)
     where
         T: TransportLayer + 'static,
@@ -213,6 +239,7 @@ impl Session {
             early_stopping,
             event_rx,
             user_event_tx.clone(),
+            worker_post_actions,
         );
 
         (event_listener.listen().await, req_txs)
@@ -240,7 +267,7 @@ impl Session {
         T: TransportLayer + 'static,
     {
         match algorithm {
-            AlgorithmConfig::ParameterServer { .. } => {
+            AlgorithmConfig::ParameterServer { .. } | AlgorithmConfig::StrategySwitch { .. } => {
                 Self::finalize_parameter_server(server_handles, user_event_tx).await
             }
             AlgorithmConfig::AllReduce => {
@@ -381,14 +408,15 @@ impl Session {
     ///
     /// # Returns
     /// The worker handles or an orch error if occurred.
-    async fn create_servers<F>(
-        servers: Vec<(String, ServerSpec)>,
+    async fn create_servers<I, F>(
+        servers: I,
         connector: &Connector<OwnedReadHalf, OwnedWriteHalf, NetRtp, F>,
     ) -> Result<Vec<ParamServerHandle<NetRtp>>>
     where
+        I: IntoIterator<Item = (String, ServerSpec)>,
         F: Fn(OwnedReadHalf, OwnedWriteHalf) -> NetRtp,
     {
-        let mut handles = Vec::with_capacity(servers.len());
+        let mut handles = Vec::new();
 
         for (i, (addr, spec)) in servers.into_iter().enumerate() {
             let stream =
@@ -421,12 +449,13 @@ impl Session {
     ///
     /// # Returns
     /// The worker handles or an orch error if occurred.
-    async fn create_workers<'a, F>(
-        workers: Vec<(String, WorkerSpec, Partition<'a>)>,
+    async fn create_workers<'a, F, I>(
+        workers: I,
         connector: &Connector<OwnedReadHalf, OwnedWriteHalf, NetRtp, F>,
     ) -> Result<Vec<WorkerHandle<NetRtp>>>
     where
         F: Fn(OwnedReadHalf, OwnedWriteHalf) -> NetRtp,
+        I: IntoIterator<Item = (String, WorkerSpec, Partition<'a>)>,
     {
         const CHUNK_SIZE: usize = 8192;
 

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -1,10 +1,8 @@
 use std::{collections::HashSet, io::SeekFrom, path::Path, thread};
 
 use comms::{
-    Connector, NetRtp, ParamServerHandle, TransportLayer, WorkerHandle,
-    protocol::Entity,
+    Connector, NetRtp, ParamServerHandle, TransportLayer, WorkerHandle, protocol::Entity,
     share_dataset,
-    specs::{server::ServerSpec, worker::WorkerSpec},
 };
 use futures::future;
 use log::{debug, error, info};
@@ -19,20 +17,21 @@ use tokio::{
     sync::mpsc::{self, Receiver, Sender},
 };
 
-use super::{EventListener, SwitchTracker, TrainedModel, WorkerListener, WorkerRequest};
+use super::{EventListener, TrainedModel, WorkerListener, WorkerRequest};
 use crate::{
     OrchErr, Result, StopReason, TrainingEvent,
-    configs::{AlgorithmConfig, OrchAdapt, Partition, ServerAdapt, WorkerAdapt, WorkerPostAction},
+    configs::{
+        AlgorithmConfig, OrchAdapt, Partition, ServerAdapt, StrategySwitchTracking, WorkerAdapt,
+    },
     sessions::{ConvergenceTracker, LossRecorder},
 };
 
 /// An ongoing training session.
 pub struct Session {
     runtime: Runtime,
+    orch_adapt: OrchAdapt,
     worker_handles: Vec<WorkerHandle<NetRtp>>,
     server_handles: Vec<ParamServerHandle<NetRtp>>,
-    orch_adapt: OrchAdapt,
-    worker_post_actions: Option<Vec<WorkerPostAction>>,
 }
 
 impl Session {
@@ -63,42 +62,26 @@ impl Session {
 
         let server_handles = match orch.algorithm_config {
             AlgorithmConfig::ParameterServer { .. } => {
-                let servers_create = servers
-                    .into_iter()
-                    .map(|ServerAdapt { addr, spec }| (addr, spec));
-
                 info!("connecting to {nservers} servers");
-                let server_handles =
-                    runtime.block_on(Self::create_servers(servers_create, &connector))?;
+                let server_handles = runtime.block_on(Self::create_servers(servers, &connector))?;
                 info!("successfully created servers");
                 server_handles
             }
             _ => Vec::new(),
         };
 
-        let (workers_create, worker_post_actions): (Vec<_>, Vec<_>) = workers
-            .into_iter()
-            .map(
-                |WorkerAdapt {
-                     addr,
-                     spec,
-                     partition,
-                     post_action,
-                 }| ((addr, spec, partition), post_action),
-            )
-            .unzip();
-
         info!("connecting to {nworkers} workers");
-        let worker_handles = runtime.block_on(Self::create_workers(workers_create, &connector))?;
+        let worker_handles = runtime.block_on(Self::create_workers(workers, &connector))?;
         info!("successfully created workers");
 
-        Ok(Self {
+        let session = Self {
             runtime,
             orch_adapt: orch,
             worker_handles,
             server_handles,
-            worker_post_actions: worker_post_actions.into_iter().collect(),
-        })
+        };
+
+        Ok(session)
     }
 
     /// Consumes `self` and creates an event listener for this training session.
@@ -119,15 +102,14 @@ impl Session {
             runtime,
             worker_handles,
             server_handles,
-            worker_post_actions,
             orch_adapt:
                 OrchAdapt {
                     input_size,
                     loss_recorder,
                     convergence_tracker,
-                    switch_tracker,
                     model_config,
                     algorithm_config,
+                    switch_tracking,
                 },
         } = self;
 
@@ -142,8 +124,7 @@ impl Session {
                 loss_recorder,
                 convergence_tracker,
                 &user_event_tx,
-                worker_post_actions,
-                switch_tracker,
+                switch_tracking,
             )
             .await
             else {
@@ -187,26 +168,21 @@ impl Session {
     /// * `loss_recorder` - The workers' loss recorder.
     /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `user_event_tx` - The user event producer.
-    /// * `worker_post_actions` - The actions to take per worker for strategy switch.
-    /// * `switch_tracker` - The tracker needed for strategy switch triggering.
+    /// * `switch_tracking` - The strategy switch tracking metadata.
     ///
     /// # Returns
     /// The worker listener requesters and the stopping reason for the training.
     #[allow(clippy::too_many_arguments)]
-    async fn start_training<T>(
-        worker_handles: Vec<WorkerHandle<T>>,
+    async fn start_training(
+        worker_handles: Vec<WorkerHandle<NetRtp>>,
         event_rx: &mut Receiver<TrainingEvent>,
         event_tx: &Sender<TrainingEvent>,
         cancel_rx: Receiver<()>,
         loss_recorder: LossRecorder,
         convergence_tracker: Option<ConvergenceTracker>,
         user_event_tx: &Sender<TrainingEvent>,
-        worker_post_actions: Option<Vec<WorkerPostAction>>,
-        switch_tracker: Option<SwitchTracker>,
-    ) -> (Option<StopReason>, Vec<Sender<WorkerRequest>>)
-    where
-        T: TransportLayer + 'static,
-    {
+        switch_tracking: Option<StrategySwitchTracking>,
+    ) -> (Option<StopReason>, Vec<Sender<WorkerRequest>>) {
         let mut req_txs = Self::spawn_worker_listeners(worker_handles, event_tx);
 
         let mut event_listener = EventListener::new(
@@ -216,8 +192,7 @@ impl Session {
             convergence_tracker,
             event_rx,
             user_event_tx.clone(),
-            worker_post_actions,
-            switch_tracker,
+            switch_tracking,
         );
 
         (event_listener.listen().await, req_txs)
@@ -262,13 +237,10 @@ impl Session {
     ///
     /// # Returns
     /// A list of senders to make requests to the listeners.
-    fn spawn_worker_listeners<T>(
-        worker_handles: Vec<WorkerHandle<T>>,
+    fn spawn_worker_listeners(
+        worker_handles: Vec<WorkerHandle<NetRtp>>,
         event_tx: &Sender<TrainingEvent>,
-    ) -> Vec<Sender<WorkerRequest>>
-    where
-        T: TransportLayer + 'static,
-    {
+    ) -> Vec<Sender<WorkerRequest>> {
         let mut req_txs = Vec::with_capacity(worker_handles.len());
 
         for (i, worker_handle) in worker_handles.into_iter().enumerate() {
@@ -391,12 +363,14 @@ impl Session {
         connector: &Connector<OwnedReadHalf, OwnedWriteHalf, NetRtp, F>,
     ) -> Result<Vec<ParamServerHandle<NetRtp>>>
     where
-        I: IntoIterator<Item = (String, ServerSpec)>,
+        I: IntoIterator<Item = ServerAdapt>,
         F: Fn(OwnedReadHalf, OwnedWriteHalf) -> NetRtp,
     {
         let mut handles = Vec::new();
 
-        for (i, (addr, spec)) in servers.into_iter().enumerate() {
+        for (i, ServerAdapt { addr, spec }) in servers.into_iter().enumerate() {
+            debug!("connecting to server at {addr}");
+
             let stream =
                 TcpStream::connect(&addr)
                     .await
@@ -433,14 +407,20 @@ impl Session {
     ) -> Result<Vec<WorkerHandle<NetRtp>>>
     where
         F: Fn(OwnedReadHalf, OwnedWriteHalf) -> NetRtp,
-        I: IntoIterator<Item = (String, WorkerSpec, Partition<'a>)>,
+        I: IntoIterator<Item = WorkerAdapt<'a>>,
     {
         const CHUNK_SIZE: usize = 8192;
 
         let futs = workers
             .into_iter()
             .enumerate()
-            .map(|(i, (addr, spec, partition))| async move {
+            .map(|(i, adapt)| async move {
+                let WorkerAdapt {
+                    addr,
+                    spec,
+                    partition,
+                } = adapt;
+
                 debug!("connecting to worker at {addr}");
 
                 let stream =

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -172,7 +172,6 @@ impl Session {
     ///
     /// # Returns
     /// The worker listener requesters and the stopping reason for the training.
-    #[allow(clippy::too_many_arguments)]
     async fn start_training(
         worker_handles: Vec<WorkerHandle<NetRtp>>,
         event_rx: &mut Receiver<TrainingEvent>,
@@ -500,7 +499,6 @@ impl Session {
     ///
     /// # Returns
     /// An orch error if occurred.
-    #[allow(clippy::too_many_arguments)]
     async fn send_local_partition<T>(
         worker_handle: &mut WorkerHandle<T>,
         samples_path: &Path,

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -101,7 +101,7 @@ impl Session {
         let Self {
             runtime,
             worker_handles,
-            server_handles,
+            mut server_handles,
             orch_adapt:
                 OrchAdapt {
                     input_size,
@@ -125,6 +125,7 @@ impl Session {
                 convergence_tracker,
                 &user_event_tx,
                 switch_tracking,
+                &mut server_handles,
             )
             .await
             else {
@@ -169,6 +170,7 @@ impl Session {
     /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `user_event_tx` - The user event producer.
     /// * `switch_tracking` - The strategy switch tracking metadata.
+    /// * `server_handles` - The server handles session vec.
     ///
     /// # Returns
     /// The worker listener requesters and the stopping reason for the training.
@@ -181,12 +183,14 @@ impl Session {
         convergence_tracker: Option<ConvergenceTracker>,
         user_event_tx: &Sender<TrainingEvent>,
         switch_tracking: Option<StrategySwitchTracking>,
+        server_handles: &mut Vec<ParamServerHandle<NetRtp>>,
     ) -> (Option<StopReason>, Vec<Sender<WorkerRequest>>) {
         let mut req_txs = Self::spawn_worker_listeners(worker_handles, event_tx);
 
         let mut event_listener = EventListener::new(
             cancel_rx,
             &mut req_txs,
+            server_handles,
             loss_recorder,
             convergence_tracker,
             event_rx,

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -223,11 +223,17 @@ impl Session {
         T: TransportLayer + 'static,
     {
         match algorithm {
-            AlgorithmConfig::ParameterServer { .. } | AlgorithmConfig::StrategySwitch { .. } => {
+            AlgorithmConfig::ParameterServer { .. } => {
                 Self::finalize_parameter_server(server_handles, user_event_tx).await
             }
             AlgorithmConfig::AllReduce => {
                 Self::finalize_all_reduce(req_txs, event_rx, user_event_tx).await
+            }
+            AlgorithmConfig::StrategySwitch { .. } if server_handles.is_empty() => {
+                Self::finalize_all_reduce(req_txs, event_rx, user_event_tx).await
+            }
+            AlgorithmConfig::StrategySwitch { .. } => {
+                Self::finalize_parameter_server(server_handles, user_event_tx).await
             }
         }
     }

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -19,57 +19,30 @@ use tokio::{
     sync::mpsc::{self, Receiver, Sender},
 };
 
-use super::TrainedModel;
+use super::{EventListener, SwitchTracker, TrainedModel, WorkerListener, WorkerRequest};
 use crate::{
     OrchErr, Result, StopReason, TrainingEvent,
-    configs::{
-        AlgorithmConfig, EarlyStoppingConfig, ModelConfig, Partition, ServerAdapt, WorkerAdapt,
-        WorkerPostAction,
-    },
-    sessions::{EventListener, WorkerListener, WorkerRequest},
+    configs::{AlgorithmConfig, OrchAdapt, Partition, ServerAdapt, WorkerAdapt, WorkerPostAction},
+    sessions::{ConvergenceTracker, LossRecorder},
 };
-
-/// A handle that lets any caller request an early stop of an ongoing training session.
-pub struct CancelHandle(Sender<()>);
-
-impl CancelHandle {
-    /// Creates a matched `(CancelHandle, Receiver)` pair.
-    ///
-    /// The caller retains the `CancelHandle` and passes the `Receiver` to
-    /// `Session::event_listener`. Calling `stop()` on the handle signals
-    /// the session to stop at the next epoch boundary.
-    pub fn pair() -> (Self, Receiver<()>) {
-        let (tx, rx) = mpsc::channel(1);
-        (Self(tx), rx)
-    }
-
-    pub fn stop(&self) {
-        let _ = self.0.try_send(());
-    }
-}
 
 /// An ongoing training session.
 pub struct Session {
     runtime: Runtime,
     worker_handles: Vec<WorkerHandle<NetRtp>>,
     server_handles: Vec<ParamServerHandle<NetRtp>>,
+    orch_adapt: OrchAdapt,
     worker_post_actions: Option<Vec<WorkerPostAction>>,
-    model: ModelConfig,
-    algorithm: AlgorithmConfig,
-    input_size: usize,
-    early_stopping: Option<EarlyStoppingConfig>,
 }
 
 impl Session {
     /// Creates a new session by connecting to all workers and servers.
     ///
     /// # Args
+    /// * `orch` - The orchestrator's values for orchestrating the session.
     /// * `workers` - The workers' network addresses, specifications and dataset partitions.
     /// * `servers` - The servers' network addresses and specifications.
     /// * `connector` - The network connector.
-    /// * `model` - The model's architecture configuration.
-    /// * `training` - The model's training configuration.
-    /// * `input_size` - The model's input size.
     ///
     /// # Returns
     /// A ready session with all connections established.
@@ -77,13 +50,10 @@ impl Session {
     /// # Errors
     /// Returns an `OrchErr` if any connection or bootstrap message fails.
     pub fn new<F>(
+        orch: OrchAdapt,
         workers: Vec<WorkerAdapt<'_>>,
         servers: Vec<ServerAdapt>,
         connector: Connector<OwnedReadHalf, OwnedWriteHalf, NetRtp, F>,
-        model: ModelConfig,
-        algorithm: AlgorithmConfig,
-        input_size: usize,
-        early_stopping: Option<EarlyStoppingConfig>,
     ) -> Result<Self>
     where
         F: Fn(OwnedReadHalf, OwnedWriteHalf) -> NetRtp,
@@ -91,7 +61,7 @@ impl Session {
         let runtime = Builder::new_multi_thread().enable_all().build()?;
         let (nworkers, nservers) = (workers.len(), servers.len());
 
-        let server_handles = match algorithm {
+        let server_handles = match orch.algorithm_config {
             AlgorithmConfig::ParameterServer { .. } => {
                 let servers_create = servers
                     .into_iter()
@@ -124,12 +94,9 @@ impl Session {
 
         Ok(Self {
             runtime,
+            orch_adapt: orch,
             worker_handles,
             server_handles,
-            model,
-            algorithm,
-            input_size,
-            early_stopping,
             worker_post_actions: worker_post_actions.into_iter().collect(),
         })
     }
@@ -152,11 +119,16 @@ impl Session {
             runtime,
             worker_handles,
             server_handles,
-            model,
-            algorithm,
-            input_size,
-            early_stopping,
             worker_post_actions,
+            orch_adapt:
+                OrchAdapt {
+                    input_size,
+                    loss_recorder,
+                    convergence_tracker,
+                    switch_tracker,
+                    model_config,
+                    algorithm_config,
+                },
         } = self;
 
         let run_loop_fut = async move {
@@ -167,9 +139,11 @@ impl Session {
                 &mut event_rx,
                 &event_tx,
                 cancel_rx,
-                early_stopping,
+                loss_recorder,
+                convergence_tracker,
                 &user_event_tx,
                 worker_post_actions,
+                switch_tracker,
             )
             .await
             else {
@@ -177,7 +151,7 @@ impl Session {
             };
 
             let params = Self::finalize_training(
-                algorithm,
+                algorithm_config,
                 server_handles,
                 &user_event_tx,
                 &mut req_txs,
@@ -185,19 +159,16 @@ impl Session {
             )
             .await;
 
-            info!("received {} total parameters", params.len());
+            let nparams = params.len();
+            info!("received {nparams} total parameters");
 
-            let trained_model = TrainedModel {
+            let model = TrainedModel {
                 params,
-                model,
-                input_size,
+                model: model_config,
+                input_size: input_size.get(),
             };
 
-            let event = TrainingEvent::TrainingComplete {
-                model: trained_model,
-                stop_reason,
-            };
-
+            let event = TrainingEvent::TrainingComplete { model, stop_reason };
             let _ = user_event_tx.send(event).await;
         };
 
@@ -213,20 +184,25 @@ impl Session {
     /// * `event_rx` - The worker listener event receiver.
     /// * `event_tx` - The event producer for the worker listeners.
     /// * `cancel_rx` - The user's halt event receiver.
-    /// * `early_stopping` - The early stopping mechanism configuration.
+    /// * `loss_recorder` - The workers' loss recorder.
+    /// * `convergence_tracker` - A tracker device to track model convergence.
     /// * `user_event_tx` - The user event producer.
     /// * `worker_post_actions` - The actions to take per worker for strategy switch.
+    /// * `switch_tracker` - The tracker needed for strategy switch triggering.
     ///
     /// # Returns
     /// The worker listener requesters and the stopping reason for the training.
+    #[allow(clippy::too_many_arguments)]
     async fn start_training<T>(
         worker_handles: Vec<WorkerHandle<T>>,
         event_rx: &mut Receiver<TrainingEvent>,
         event_tx: &Sender<TrainingEvent>,
         cancel_rx: Receiver<()>,
-        early_stopping: Option<EarlyStoppingConfig>,
+        loss_recorder: LossRecorder,
+        convergence_tracker: Option<ConvergenceTracker>,
         user_event_tx: &Sender<TrainingEvent>,
         worker_post_actions: Option<Vec<WorkerPostAction>>,
+        switch_tracker: Option<SwitchTracker>,
     ) -> (Option<StopReason>, Vec<Sender<WorkerRequest>>)
     where
         T: TransportLayer + 'static,
@@ -236,10 +212,12 @@ impl Session {
         let mut event_listener = EventListener::new(
             cancel_rx,
             &mut req_txs,
-            early_stopping,
+            loss_recorder,
+            convergence_tracker,
             event_rx,
             user_event_tx.clone(),
             worker_post_actions,
+            switch_tracker,
         );
 
         (event_listener.listen().await, req_txs)

--- a/orchestrator/src/sessions/switch_tracker.rs
+++ b/orchestrator/src/sessions/switch_tracker.rs
@@ -46,6 +46,10 @@ impl SwitchTracker {
     /// # Returns
     /// `true` if it should switch, `false` otherwise.
     pub fn should_switch(&mut self) -> bool {
+        if self.losses.len() < *self.winsize {
+            return false;
+        }
+
         let mut sum = 0.0;
 
         for i in 1..*self.winsize {

--- a/orchestrator/src/sessions/switch_tracker.rs
+++ b/orchestrator/src/sessions/switch_tracker.rs
@@ -15,7 +15,7 @@ impl SwitchTracker {
     /// Creates a new `SwitchTracker`.
     ///
     /// # Args
-    /// * `winsize` - The amount of losses to acumulate (paper uses `5`).
+    /// * `winsize` - The amount of losses to accumulate (paper uses `5`).
     /// * `threshold` - The trigger value for `s` (paper uses `0.01`).
     ///
     /// # Returns
@@ -28,8 +28,8 @@ impl SwitchTracker {
         }
     }
 
-    /// Records a new loss onto the tracker and decides weather to
-    /// switch algorithms or continue trianing under the same algorithm.
+    /// Records a new loss onto the tracker and decides whether to
+    /// switch algorithms or continue training under the same algorithm.
     ///
     /// # Args
     /// * `loss` - The new loss to accumulate.
@@ -45,7 +45,7 @@ impl SwitchTracker {
     ///
     /// # Returns
     /// `true` if it should switch, `false` otherwise.
-    pub fn should_switch(&mut self) -> bool {
+    pub fn should_switch(&self) -> bool {
         if self.losses.len() < *self.winsize {
             return false;
         }
@@ -57,7 +57,7 @@ impl SwitchTracker {
             sum += delta.abs() / self.losses[i - 1];
         }
 
-        let s = sum / *self.winsize as f64;
+        let s = sum / (*self.winsize - 1) as f64;
         s <= self.threshold
     }
 }

--- a/orchestrator/src/sessions/switch_tracker.rs
+++ b/orchestrator/src/sessions/switch_tracker.rs
@@ -1,0 +1,59 @@
+use std::collections::VecDeque;
+
+use super::GreaterThanOneUsize;
+
+/// The entity responsible of detecting and engaging the algorithm switch
+/// when training under Strategy Switch.
+#[derive(Debug)]
+pub struct SwitchTracker {
+    winsize: GreaterThanOneUsize,
+    threshold: f64,
+    losses: VecDeque<f64>,
+}
+
+impl SwitchTracker {
+    /// Creates a new `SwitchTracker`.
+    ///
+    /// # Args
+    /// * `winsize` - The amount of losses to acumulate (paper uses `5`).
+    /// * `threshold` - The trigger value for `s` (paper uses `0.01`).
+    ///
+    /// # Returns
+    /// A new `SwitchTracker` instance.
+    pub fn new(winsize: GreaterThanOneUsize, threshold: f64) -> Self {
+        Self {
+            winsize,
+            threshold,
+            losses: VecDeque::with_capacity(*winsize),
+        }
+    }
+
+    /// Records a new loss onto the tracker and decides weather to
+    /// switch algorithms or continue trianing under the same algorithm.
+    ///
+    /// # Args
+    /// * `loss` - The new loss to accumulate.
+    pub fn record(&mut self, loss: f64) {
+        if self.losses.len() == *self.winsize {
+            self.losses.pop_front();
+        }
+
+        self.losses.push_back(loss);
+    }
+
+    /// Determines when the switch should occur.
+    ///
+    /// # Returns
+    /// `true` if it should switch, `false` otherwise.
+    pub fn should_switch(&mut self) -> bool {
+        let mut sum = 0.0;
+
+        for i in 1..*self.winsize {
+            let delta = self.losses[i] - self.losses[i - 1];
+            sum += delta.abs() / self.losses[i - 1];
+        }
+
+        let s = sum / *self.winsize as f64;
+        s <= self.threshold
+    }
+}

--- a/orchestrator/src/sessions/worker_listener.rs
+++ b/orchestrator/src/sessions/worker_listener.rs
@@ -180,7 +180,7 @@ impl WorkerListener {
 
                 if let Err(e) = self
                     .worker_handle
-                    .switch(server_addrs, server_sizes, server_ordering, trainer_spec)
+                    .switch(server_addrs, server_sizes, server_ordering, *trainer_spec)
                     .await
                 {
                     let details = format!("failed to switch worker {id}: {e}");

--- a/orchestrator/src/sessions/worker_listener.rs
+++ b/orchestrator/src/sessions/worker_listener.rs
@@ -1,4 +1,4 @@
-use comms::{NetRtp, WorkerEvent, WorkerHandle, specs::server::ServerSpec};
+use comms::{NetRtp, ParamServerHandle, WorkerEvent, WorkerHandle, specs::server::ServerSpec};
 use log::{debug, error, info, warn};
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -63,25 +63,28 @@ impl WorkerListener {
         loop {
             tokio::select! {
                 req = req_rx.recv() => {
-                    if let Some(req) = req {
-                        match self.handle_request(req, &event_tx).await {
-                            Ok(ReqResolution::Continue) => continue,
-                            Ok(ReqResolution::Halt) => {},
-                            Ok(ReqResolution::Upgrade { spec, ranges }) => {
-                                let event = match self.worker_handle.upgrade(spec, ranges).await {
-                                    Ok(server_handle) => TrainingEvent::Upgrade { server_handle },
-                                    Err(e) => {
-                                        let err = OrchErr::WorkerError { id, details: e.to_string() };
-                                        TrainingEvent::Error(err)
-                                    }
-                                };
+                    let Some(req) = req else {
+                        continue;
+                    };
 
-                                let _ = event_tx.send(event).await;
-                            },
-                            Err(e) => { let _ = event_tx.send(TrainingEvent::Error(e)).await; }
+                    match self.handle_request(req, &event_tx).await {
+                        Ok(ReqResolution::Continue) => {},
+                        Ok(ReqResolution::Halt) => break,
+                        Ok(ReqResolution::Upgrade { spec, ranges }) => {
+                            let event = match self.handle_upgrade(spec, ranges).await {
+                                Ok(server_handle) => TrainingEvent::Upgrade {
+                                    server_handle: Box::new(server_handle)
+                                },
+                                Err(e) => TrainingEvent::Error(e),
+                            };
+
+                            let _ = event_tx.send(event).await;
+                            break
+                        },
+                        Err(e) => {
+                            let _ = event_tx.send(TrainingEvent::Error(e)).await;
+                            break;
                         }
-
-                        break;
                     }
                 },
                 event = self.worker_handle.recv_event() => match event {
@@ -181,7 +184,10 @@ impl WorkerListener {
 
                 ReqResolution::Continue
             }
-            WorkerRequest::Upgrade { spec, ranges } => ReqResolution::Upgrade { spec, ranges },
+            WorkerRequest::Upgrade { spec, ranges } => ReqResolution::Upgrade {
+                spec: *spec,
+                ranges,
+            },
         };
 
         Ok(should_continue)
@@ -222,5 +228,27 @@ impl WorkerListener {
                 Err(OrchErr::WorkerError { id, details })
             }
         }
+    }
+
+    /// Sends an upgrade message to the worker.
+    ///
+    /// # Args
+    /// * `spec` - The specification for the server instanciation.
+    /// * `ranges` - The requested parameter ranges for this server.
+    ///
+    /// # Returns
+    /// The `ParamServerHandle` to communicate with the server or an orch err if occurred.
+    async fn handle_upgrade(
+        self,
+        spec: ServerSpec,
+        ranges: Vec<(usize, usize)>,
+    ) -> Result<ParamServerHandle<NetRtp>> {
+        self.worker_handle
+            .upgrade(spec, ranges)
+            .await
+            .map_err(|e| OrchErr::WorkerError {
+                id: self.id,
+                details: e.to_string(),
+            })
     }
 }

--- a/orchestrator/src/sessions/worker_listener.rs
+++ b/orchestrator/src/sessions/worker_listener.rs
@@ -71,6 +71,8 @@ impl WorkerListener {
                         Ok(ReqResolution::Continue) => {},
                         Ok(ReqResolution::Halt) => break,
                         Ok(ReqResolution::Upgrade { spec, ranges }) => {
+                            info!("upgrading worker {id}");
+
                             let event = match self.handle_upgrade(spec, ranges).await {
                                 Ok(server_handle) => TrainingEvent::Upgrade {
                                     server_handle: Box::new(server_handle)
@@ -173,6 +175,8 @@ impl WorkerListener {
                 server_sizes,
                 server_ordering,
             } => {
+                info!("switching worker {id}");
+
                 if let Err(e) = self
                     .worker_handle
                     .switch(server_addrs, server_sizes, server_ordering)

--- a/orchestrator/src/sessions/worker_listener.rs
+++ b/orchestrator/src/sessions/worker_listener.rs
@@ -1,9 +1,19 @@
-use comms::{TransportLayer, WorkerEvent, WorkerHandle};
+use comms::{NetRtp, WorkerEvent, WorkerHandle, specs::server::ServerSpec};
 use log::{debug, error, info, warn};
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use super::{TrainingEvent, WorkerRequest};
 use crate::{OrchErr, Result};
+
+/// The return type of the `handle_request` method.
+enum ReqResolution {
+    Upgrade {
+        spec: ServerSpec,
+        ranges: Vec<(usize, usize)>,
+    },
+    Continue,
+    Halt,
+}
 
 /// The return type of the `handle_event` method.
 enum EventResolution {
@@ -12,19 +22,13 @@ enum EventResolution {
 }
 
 /// The worker handle manager.
-pub struct WorkerListener<T>
-where
-    T: TransportLayer,
-{
+pub struct WorkerListener {
     id: usize,
-    worker_handle: WorkerHandle<T>,
+    worker_handle: WorkerHandle<NetRtp>,
     stopping: bool,
 }
 
-impl<T> WorkerListener<T>
-where
-    T: TransportLayer,
-{
+impl WorkerListener {
     /// Creates a new `WorkerListener`.
     ///
     /// # Args
@@ -33,7 +37,7 @@ where
     ///
     /// # Returns
     /// A new `WorkerListener` instance.
-    pub fn new(id: usize, worker_handle: WorkerHandle<T>) -> Self {
+    pub fn new(id: usize, worker_handle: WorkerHandle<NetRtp>) -> Self {
         Self {
             id,
             worker_handle,
@@ -61,13 +65,23 @@ where
                 req = req_rx.recv() => {
                     if let Some(req) = req {
                         match self.handle_request(req, &event_tx).await {
-                            Ok(false) => break,
-                            Err(e) => {
-                                let _ = event_tx.send(TrainingEvent::Error(e)).await;
-                                break;
-                            }
-                            _ => {}
+                            Ok(ReqResolution::Continue) => continue,
+                            Ok(ReqResolution::Halt) => {},
+                            Ok(ReqResolution::Upgrade { spec, ranges }) => {
+                                let event = match self.worker_handle.upgrade(spec, ranges).await {
+                                    Ok(server_handle) => TrainingEvent::Upgrade { server_handle },
+                                    Err(e) => {
+                                        let err = OrchErr::WorkerError { id, details: e.to_string() };
+                                        TrainingEvent::Error(err)
+                                    }
+                                };
+
+                                let _ = event_tx.send(event).await;
+                            },
+                            Err(e) => { let _ = event_tx.send(TrainingEvent::Error(e)).await; }
                         }
+
+                        break;
                     }
                 },
                 event = self.worker_handle.recv_event() => match event {
@@ -104,10 +118,7 @@ where
         &mut self,
         req: WorkerRequest,
         event_tx: &Sender<TrainingEvent>,
-    ) -> Result<bool>
-    where
-        T: TransportLayer,
-    {
+    ) -> Result<ReqResolution> {
         let id = self.id;
 
         let should_continue = match req {
@@ -122,7 +133,7 @@ where
                 }
 
                 let _ = event_tx.send(event).await;
-                false
+                ReqResolution::Halt
             }
             WorkerRequest::Stop => {
                 if !self.stopping {
@@ -136,7 +147,7 @@ where
                     self.stopping = true;
                 }
 
-                true
+                ReqResolution::Continue
             }
             WorkerRequest::PullParams => {
                 info!("pulling parmaeters from worker {id}");
@@ -152,8 +163,25 @@ where
                     }
                 }
 
-                true
+                ReqResolution::Continue
             }
+            WorkerRequest::Switch {
+                server_addrs,
+                server_sizes,
+                server_ordering,
+            } => {
+                if let Err(e) = self
+                    .worker_handle
+                    .switch(server_addrs, server_sizes, server_ordering)
+                    .await
+                {
+                    let details = format!("failed to switch worker {id}: {e}");
+                    return Err(OrchErr::WorkerError { id, details });
+                }
+
+                ReqResolution::Continue
+            }
+            WorkerRequest::Upgrade { spec, ranges } => ReqResolution::Upgrade { spec, ranges },
         };
 
         Ok(should_continue)
@@ -167,10 +195,7 @@ where
     ///
     /// # Returns
     /// An `EventResolution` or an orch error if the received event is invalid.
-    fn handle_event(id: usize, event: WorkerEvent<'_>) -> Result<EventResolution>
-    where
-        T: TransportLayer,
-    {
+    fn handle_event(id: usize, event: WorkerEvent<'_>) -> Result<EventResolution> {
         match event {
             WorkerEvent::Loss(losses) => {
                 debug!("worker {id} reported {} losses", losses.len());

--- a/orchestrator/src/sessions/worker_listener.rs
+++ b/orchestrator/src/sessions/worker_listener.rs
@@ -174,12 +174,13 @@ impl WorkerListener {
                 server_addrs,
                 server_sizes,
                 server_ordering,
+                trainer_spec,
             } => {
                 info!("switching worker {id}");
 
                 if let Err(e) = self
                     .worker_handle
-                    .switch(server_addrs, server_sizes, server_ordering)
+                    .switch(server_addrs, server_sizes, server_ordering, trainer_spec)
                     .await
                 {
                     let details = format!("failed to switch worker {id}: {e}");

--- a/orchestui/Cargo.toml
+++ b/orchestui/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = "1"
 orchestrator = { path = "../orchestrator" }
 env_logger = "0.11"
 open = "5"
+
+[lints]
+workspace = true

--- a/orchestui/src/config/json.rs
+++ b/orchestui/src/config/json.rs
@@ -49,9 +49,12 @@ pub fn load_training(path: &str) -> Result<TrainingJson, String> {
         serde_json::from_str(&content).map_err(|e| format!("invalid training config: {e}"))?;
 
     let (worker_count, server_count) = match &config.algorithm {
-        AlgorithmConfig::ParameterServer { server_addrs, .. }
-        | AlgorithmConfig::StrategySwitch { server_addrs, .. } => {
+        AlgorithmConfig::ParameterServer { server_addrs, .. } => {
             (config.worker_addrs.len(), server_addrs.len())
+        }
+        AlgorithmConfig::StrategySwitch { server_addrs, .. } => {
+            // All nodes start as AllReduce workers; server_addrs nodes are upgraded later.
+            (config.worker_addrs.len() + server_addrs.len(), 0)
         }
         AlgorithmConfig::AllReduce => (config.worker_addrs.len(), 0),
     };
@@ -61,4 +64,83 @@ pub fn load_training(path: &str) -> Result<TrainingJson, String> {
         worker_count,
         server_count,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_switch_worker_count_includes_server_addrs() {
+        let json = r#"{
+            "worker_addrs": ["127.0.0.1:50000", "127.0.0.1:50001"],
+            "algorithm": {
+                "strategy_switch": {
+                    "server_addrs": ["127.0.0.1:40000"],
+                    "synchronizer": "non_blocking",
+                    "store": "wild"
+                }
+            },
+            "serializer": "base",
+            "dataset": {
+                "src": { "inline": { "samples": [0.1, 0.2, 0.3, 0.4], "labels": [0.3] } },
+                "x_size": 4,
+                "y_size": 1
+            },
+            "optimizer": { "gradient_descent": { "lr": 0.01 } },
+            "loss_fn": "mse",
+            "batch_size": 4,
+            "max_epochs": 10,
+            "offline_epochs": 0,
+            "seed": null,
+            "early_stopping": null
+        }"#;
+
+        let config: TrainingConfig = serde_json::from_str(json).expect("parse failed");
+
+        if let AlgorithmConfig::StrategySwitch { server_addrs, .. } = &config.algorithm {
+            let worker_count = config.worker_addrs.len() + server_addrs.len();
+            assert_eq!(worker_count, 3);
+        } else {
+            panic!("expected StrategySwitch");
+        }
+    }
+
+    #[test]
+    fn parameter_server_worker_count_excludes_server_addrs() {
+        let json = r#"{
+            "worker_addrs": ["127.0.0.1:50000"],
+            "algorithm": {
+                "parameter_server": {
+                    "server_addrs": ["127.0.0.1:40000", "127.0.0.1:40001"],
+                    "synchronizer": "barrier",
+                    "store": "blocking"
+                }
+            },
+            "serializer": "base",
+            "dataset": {
+                "src": { "inline": { "samples": [0.1, 0.2], "labels": [0.3] } },
+                "x_size": 2,
+                "y_size": 1
+            },
+            "optimizer": { "gradient_descent": { "lr": 0.01 } },
+            "loss_fn": "mse",
+            "batch_size": 4,
+            "max_epochs": 10,
+            "offline_epochs": 0,
+            "seed": null,
+            "early_stopping": null
+        }"#;
+
+        let config: TrainingConfig = serde_json::from_str(json).expect("parse failed");
+
+        if let AlgorithmConfig::ParameterServer { server_addrs, .. } = &config.algorithm {
+            let worker_count = config.worker_addrs.len();
+            let server_count = server_addrs.len();
+            assert_eq!(worker_count, 1);
+            assert_eq!(server_count, 2);
+        } else {
+            panic!("expected ParameterServer");
+        }
+    }
 }

--- a/orchestui/src/config/json.rs
+++ b/orchestui/src/config/json.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use orchestrator::configs::{AlgorithmConfig, ModelConfig, TrainingConfig};
 
 /// Parsed model architecture from `model.json`.
@@ -25,8 +27,7 @@ pub struct TrainingJson {
 /// # Errors
 /// Returns a human-readable string if the file cannot be read or parsed.
 pub fn load_model(path: &str) -> Result<ModelJson, String> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
+    let content = fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
     let config: ModelConfig =
         serde_json::from_str(&content).map_err(|e| format!("invalid model config: {e}"))?;
     Ok(ModelJson { config })
@@ -43,13 +44,13 @@ pub fn load_model(path: &str) -> Result<ModelJson, String> {
 /// # Errors
 /// Returns a human-readable string if the file cannot be read or parsed.
 pub fn load_training(path: &str) -> Result<TrainingJson, String> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
+    let content = fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
     let config: TrainingConfig =
         serde_json::from_str(&content).map_err(|e| format!("invalid training config: {e}"))?;
 
     let (worker_count, server_count) = match &config.algorithm {
-        AlgorithmConfig::ParameterServer { server_addrs, .. } => {
+        AlgorithmConfig::ParameterServer { server_addrs, .. }
+        | AlgorithmConfig::StrategySwitch { server_addrs, .. } => {
             (config.worker_addrs.len(), server_addrs.len())
         }
         AlgorithmConfig::AllReduce => (config.worker_addrs.len(), 0),

--- a/orchestui/src/ui/screens/training.rs
+++ b/orchestui/src/ui/screens/training.rs
@@ -95,10 +95,7 @@ pub enum LogLevel {
     Error,
 }
 
-enum StartupResult {
-    Ok(Session),
-    Err(String),
-}
+type StartupResult = Result<Session, String>;
 
 /// Full state for the training dashboard screen.
 pub struct TrainingState {

--- a/parameter_server/Cargo.toml
+++ b/parameter_server/Cargo.toml
@@ -14,3 +14,6 @@ rand = "0.9.2"
 rayon = "1.11.0"
 tokio = { version = "1.48.0", features = ["full"] }
 trait-variant = "0.1.2"
+
+[lints]
+workspace = true

--- a/strategy-switch.md
+++ b/strategy-switch.md
@@ -1,0 +1,8 @@
+# Notes
+
+1. Hay que agregar una manera de medir cuando se va a efectuar el switch y una manera de ejecutarlo (seria mandar los
+   mensajes ya definidos en `comms/src/protocol/msg.rs`).
+2. Hay que leer bien cual es la regla del switch, una vez que tenga esto implementado deberia estar listo para probar
+   el algoritmo.
+3. Puedo usar el ConvergenceTracker para esto, estaria bueno tener una ventana mas grande, se ve que en el paper es de
+   las 5 losses anteriores, una vez que alcanza o supera un `s` entonces se triggerea el switch.

--- a/strategy-switch.md
+++ b/strategy-switch.md
@@ -6,3 +6,6 @@
    el algoritmo.
 3. Puedo usar el ConvergenceTracker para esto, estaria bueno tener una ventana mas grande, se ve que en el paper es de
    las 5 losses anteriores, una vez que alcanza o supera un `s` entonces se triggerea el switch.
+
+Armar un loss recorder para ir registrando las losses de los workers, una vez que tengo la loss creada, le puedo pedir la mean, max, etc.
+Luego esa loss se la doy al switch_tracker.

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -25,3 +25,6 @@ tokio = { version = "1", features = [
   "time",
   "io-util",
 ] }
+
+[lints]
+workspace = true

--- a/worker/src/builder.rs
+++ b/worker/src/builder.rs
@@ -3,12 +3,15 @@ use std::io;
 use comms::{
     Acceptor, Connection, Connector, DatasetSrc, OrchHandle, ParamServerHandle, TransportLayer,
     protocol::Entity,
-    specs::worker::{AlgorithmSpec, SerializerSpec, WorkerSpec},
+    specs::{
+        machine_learning::TrainerSpec,
+        worker::{AlgorithmSpec, SerializerSpec, WorkerSpec},
+    },
 };
 use machine_learning::{
-    datasets::DataSrc,
+    datasets::{DataSrc, Dataset},
     initialization::ParamGenBuilder,
-    training::{Trainer, TrainerBuilder},
+    training::TrainerBuilder,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -154,7 +157,8 @@ where
     /// * `server_addrs` - The servers' network addresses.
     /// * `server_sizes` - The sizes of the worker nodes.
     /// * `server_ordering` - The ordering of the server layers.
-    /// * `trainer` - The trainer used to train until now.
+    /// * `dataset` - The dataset that the worker has been using until now.
+    /// * `trainer_spec` - The trainer specification for the new trainer.
     /// * `orch_handle` - The handle for communicating with the orchestrator.
     ///
     /// # Returns
@@ -165,7 +169,8 @@ where
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
-        mut trainer: Box<dyn Trainer>,
+        dataset: Dataset,
+        trainer_spec: TrainerSpec,
         orch_handle: &'a mut OrchHandle<T>,
     ) -> io::Result<ParamServerWorker<'a, T>> {
         let WorkerSpec {
@@ -174,6 +179,10 @@ where
             seed,
             ..
         } = spec;
+
+        let trainer_builder = TrainerBuilder::new();
+        let mut trainer = trainer_builder.build(trainer_spec, &server_sizes);
+        trainer.load_dataset(dataset.into_src());
 
         let cluster_manager = self
             .connect_to_servers(

--- a/worker/src/builder.rs
+++ b/worker/src/builder.rs
@@ -222,7 +222,6 @@ where
     ///
     /// # Returns
     /// A new `ServerClusterManager` instance or an io error if occurred.
-    #[allow(clippy::too_many_arguments)]
     async fn connect_to_servers<H>(
         &self,
         id: usize,

--- a/worker/src/workers/all_reduce.rs
+++ b/worker/src/workers/all_reduce.rs
@@ -96,13 +96,15 @@ where
                     OrchEvent::Switch {
                         server_addrs,
                         server_sizes,
-                        server_ordering
+                        server_ordering,
+                        trainer_spec,
                     } => {
                         info!("switching algorithm to parameter server as a worker");
                         return Ok(Run::Switch {
                             server_addrs,
                             server_sizes,
-                            server_ordering
+                            server_ordering,
+                            trainer_spec,
                         });
                     }
                     other => {
@@ -112,7 +114,9 @@ where
                 response = self.ring_manager.pull_grads(&mut self.params) => {
                     debug!("received gradients from all workers, training...");
 
-                    let mut param_manager = response?;
+                    let Ok(mut param_manager) = response else {
+                        continue;
+                    };
 
                     // SAFETY: The parameter and gradient buffer have the same size.
                     self.trainer.optimize(&mut param_manager).unwrap();

--- a/worker/src/workers/worker.rs
+++ b/worker/src/workers/worker.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use comms::specs::server::ServerSpec;
+use comms::specs::{machine_learning::TrainerSpec, server::ServerSpec};
 use machine_learning::training::Trainer;
 
 /// The result of running a worker instance.
@@ -11,6 +11,7 @@ pub enum Run {
         server_addrs: Vec<String>,
         server_sizes: Vec<usize>,
         server_ordering: Vec<usize>,
+        trainer_spec: TrainerSpec,
     },
     Upgrade {
         spec: ServerSpec,

--- a/worker/tests/worker_protocol.rs
+++ b/worker/tests/worker_protocol.rs
@@ -17,7 +17,6 @@ use worker::{
     workers::{ParamServerWorker, Worker},
 };
 
-#[allow(clippy::type_complexity)]
 fn channel_pair() -> (
     (ReadHalf<DuplexStream>, WriteHalf<DuplexStream>),
     (ReadHalf<DuplexStream>, WriteHalf<DuplexStream>),


### PR DESCRIPTION
Al final fue mucho más complicado de lo que pensaba pero acá está, el jodido Strategy Switch.

Rehice el `ConvergenceTracker` para que solo tenga en cuenta losses de a una, agregué un `LossRecorder` que es el que va tomando las losses de los distintos workers para generar una loss por epoch (no es tán así pero digamos que sí).

Le silencié los lints de `clippy::to_many_arguments` y `clippy::type_complexity` porque ya habian varios `#[allow(clippy::*)]` con estos dos y no me parecen mal.

Van a ver que le agrego `Debug` a varios structs, es porque ahora necesito pasar `ParamServerHandle` dentro del `TrainingEvent` que es `Debug` y me parece que está bien. Capaz estaría mejor implementar `Debug` aparte así no se lo agregaba a todo pero no me parece mal tampoco como quedó.