### PR TITLE
Ps weight collection order

### DIFF
--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -58,9 +58,10 @@ impl Adapter {
                 synchronizer,
                 store,
             } => {
-                let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
-                let (servers, server_sizes, server_ordering) =
+                let mut orch = self.adapt_non_strategy_switch_orch(&model, training)?;
+                let (servers, server_sizes, server_ordering, layer_offsets) =
                     self.adapt_servers(&model, training, server_addrs, synchronizer, store)?;
+                orch.layer_param_offsets = layer_offsets;
 
                 let partitions =
                     self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
@@ -145,6 +146,7 @@ impl Adapter {
             switch_tracking: None,
             model_config: model.clone(),
             algorithm_config: training.algorithm.clone(),
+            layer_param_offsets: Vec::new(),
         };
 
         Ok(adapt)
@@ -186,8 +188,8 @@ impl Adapter {
         let tracker = SwitchTracker::new(winsize, 0.01);
 
         let trainer_spec = self.adapt_trainer(model, training);
-        let (_, _, _, param_ranges) = self.adapt_param_gens(model, training, nservers)?;
-        let (servers, server_sizes, server_ordering) =
+        let (_, _, _, _, param_ranges) = self.adapt_param_gens(model, training, nservers)?;
+        let (servers, server_sizes, server_ordering, layer_offsets) =
             self.adapt_servers(model, training, server_addrs, synchronizer, store)?;
 
         let switches = (0..nworkers).map(|_| WorkerPostAction::Switch {
@@ -214,6 +216,7 @@ impl Adapter {
             switch_tracking: Some(tracking),
             model_config: model.clone(),
             algorithm_config: training.algorithm.clone(),
+            layer_param_offsets: layer_offsets,
         };
 
         Ok(adapt)
@@ -470,7 +473,8 @@ impl Adapter {
     /// * `store` - The store's configuration.
     ///
     /// # Returns
-    /// The servers' specifications, resolved addresses, sizes and layers' ordering.
+    /// The servers' specifications, resolved addresses, sizes, layers' ordering and per-layer
+    /// parameter offsets within each server's buffer.
     ///
     /// # Errors
     /// Returns an `OrchErr` if any address cannot be resolved.
@@ -481,8 +485,8 @@ impl Adapter {
         server_addrs: &[String],
         synchronizer: SynchronizerConfig,
         store: StoreConfig,
-    ) -> Result<(Vec<ServerAdapt>, Vec<usize>, Vec<usize>)> {
-        let (param_gens, server_sizes, server_ordering, _) =
+    ) -> Result<(Vec<ServerAdapt>, Vec<usize>, Vec<usize>, Vec<(usize, usize, usize)>)> {
+        let (param_gens, server_sizes, server_ordering, layer_offsets, _) =
             self.adapt_param_gens(model, training, server_addrs.len())?;
 
         let nworkers = training.worker_addrs.len();
@@ -518,7 +522,7 @@ impl Adapter {
             .into_iter()
             .unzip();
 
-        Ok((servers, server_sizes, server_ordering))
+        Ok((servers, server_sizes, server_ordering, layer_offsets))
     }
 
     /// Adapts the parameter generators and partitions the layers to minimize the
@@ -530,7 +534,8 @@ impl Adapter {
     /// * `nservers` - The amount of servers.
     ///
     /// # Returns
-    /// The param generator specifications, the server sizes, server orderings and the parameter ranges.
+    /// The param generator specifications, the server sizes, server orderings, the per-layer
+    /// parameter offsets within each server's buffer, and the parameter ranges.
     fn adapt_param_gens(
         &self,
         model: &ModelConfig,
@@ -540,6 +545,7 @@ impl Adapter {
         Vec<ParamGenSpec>,
         Vec<usize>,
         Vec<usize>,
+        Vec<(usize, usize, usize)>,
         Vec<Vec<(usize, usize)>>,
     )> {
         let (_, param_gens) = self.adapt_layers(model, training.dataset.x_size);
@@ -556,10 +562,16 @@ impl Adapter {
 
         let param_gen_bins = balanced_partitions(items, nservers);
         let mut server_ordering = vec![0; nlayers];
+        let mut layer_offsets = vec![(0usize, 0usize, 0usize); nlayers];
+        let mut server_cursors = vec![0usize; nservers];
 
         for (server_i, bin) in param_gen_bins.iter().enumerate() {
-            for &(layer_i, ..) in bin {
-                server_ordering[layer_i] = server_i;
+            for (layer_i, spec) in bin {
+                let size = spec.size();
+                let start = server_cursors[server_i];
+                server_ordering[*layer_i] = server_i;
+                layer_offsets[*layer_i] = (server_i, start, start + size);
+                server_cursors[server_i] += size;
             }
         }
 
@@ -595,6 +607,7 @@ impl Adapter {
             param_gen_specs,
             server_sizes,
             server_ordering,
+            layer_offsets,
             server_ranges,
         ))
     }

--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -58,10 +58,9 @@ impl Adapter {
                 synchronizer,
                 store,
             } => {
-                let mut orch = self.adapt_non_strategy_switch_orch(&model, training)?;
-                let (servers, server_sizes, server_ordering, layer_offsets) =
+                let orch = self.adapt_non_strategy_switch_orch(&model, training)?;
+                let (servers, server_sizes, server_ordering, _) =
                     self.adapt_servers(&model, training, server_addrs, synchronizer, store)?;
-                orch.layer_param_offsets = layer_offsets;
 
                 let partitions =
                     self.adapt_dataset_partitions(&training.dataset, training.worker_addrs.len())?;
@@ -139,6 +138,17 @@ impl Adapter {
             ConvergenceTracker::new(winsize, cfg.tolerance)
         });
 
+        let layer_param_offsets = if let AlgorithmConfig::ParameterServer {
+            ref server_addrs, ..
+        } = training.algorithm
+        {
+            let (_, _, _, offsets, _) =
+                self.adapt_param_gens(model, training, server_addrs.len())?;
+            offsets
+        } else {
+            Vec::new()
+        };
+
         let adapt = OrchAdapt {
             input_size: training.dataset.x_size,
             loss_recorder: LossRecorder::new(nworkers),
@@ -146,7 +156,7 @@ impl Adapter {
             switch_tracking: None,
             model_config: model.clone(),
             algorithm_config: training.algorithm.clone(),
-            layer_param_offsets: Vec::new(),
+            layer_param_offsets,
         };
 
         Ok(adapt)

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -65,7 +65,5 @@ pub struct OrchAdapt {
     pub switch_tracking: Option<StrategySwitchTracking>,
     pub model_config: ModelConfig,
     pub algorithm_config: AlgorithmConfig,
-    /// Per-layer parameter location within its server's buffer: (server_id, start, end).
-    /// Empty for AllReduce training.
     pub layer_param_offsets: Vec<(usize, usize, usize)>,
 }

--- a/orchestrator/src/configs/mod.rs
+++ b/orchestrator/src/configs/mod.rs
@@ -65,4 +65,7 @@ pub struct OrchAdapt {
     pub switch_tracking: Option<StrategySwitchTracking>,
     pub model_config: ModelConfig,
     pub algorithm_config: AlgorithmConfig,
+    /// Per-layer parameter location within its server's buffer: (server_id, start, end).
+    /// Empty for AllReduce training.
+    pub layer_param_offsets: Vec<(usize, usize, usize)>,
 }

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -315,13 +315,13 @@ impl Session {
             }
         }
 
-        let total: usize = layer_offsets.iter().map(|&(_, s, e)| e - s).sum();
+        let total: usize = layer_offsets.iter().map(|&(_, start, end)| end - start).sum();
         let mut model_params = Vec::with_capacity(total);
 
         for (layer_i, &(server_id, start, end)) in layer_offsets.iter().enumerate() {
-            if let Some(ref sp) = server_params[server_id] {
+            if let Some(ref params) = server_params[server_id] {
                 debug!("layer {layer_i}: server {server_id} [{start}..{end}]");
-                model_params.extend_from_slice(&sp[start..end]);
+                model_params.extend_from_slice(&params[start..end]);
             }
         }
 

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -110,6 +110,7 @@ impl Session {
                     model_config,
                     algorithm_config,
                     switch_tracking,
+                    layer_param_offsets,
                 },
         } = self;
 
@@ -138,6 +139,7 @@ impl Session {
                 &user_event_tx,
                 &mut req_txs,
                 &mut event_rx,
+                &layer_param_offsets,
             )
             .await;
 
@@ -209,6 +211,7 @@ impl Session {
     /// * `user_event_tx` - The user event notifier.
     /// * `req_txs` - The request senders for the worker listeners.
     /// * `event_rx` - The worker listener event consumer.
+    /// * `layer_offsets` - Per-layer parameter locations: (server_id, start, end) within each server's buffer.
     ///
     /// # Returns
     /// The trained parameters of the model.
@@ -218,13 +221,14 @@ impl Session {
         user_event_tx: &Sender<TrainingEvent>,
         req_txs: &mut [Sender<WorkerRequest>],
         event_rx: &mut Receiver<TrainingEvent>,
+        layer_offsets: &[(usize, usize, usize)],
     ) -> Vec<f32>
     where
         T: TransportLayer + 'static,
     {
         match algorithm {
             AlgorithmConfig::ParameterServer { .. } => {
-                Self::finalize_parameter_server(server_handles, user_event_tx).await
+                Self::finalize_parameter_server(server_handles, layer_offsets, user_event_tx).await
             }
             AlgorithmConfig::AllReduce => {
                 Self::finalize_all_reduce(req_txs, event_rx, user_event_tx).await
@@ -233,7 +237,7 @@ impl Session {
                 Self::finalize_all_reduce(req_txs, event_rx, user_event_tx).await
             }
             AlgorithmConfig::StrategySwitch { .. } => {
-                Self::finalize_parameter_server(server_handles, user_event_tx).await
+                Self::finalize_parameter_server(server_handles, layer_offsets, user_event_tx).await
             }
         }
     }
@@ -264,31 +268,39 @@ impl Session {
     }
 
     /// Finalizes a training using parameter server. Retrieves the parameters from
-    /// all the servers.
+    /// all the servers and reassembles them in the original layer order.
+    ///
+    /// Layers are distributed across servers by `balanced_partitions`, so pulling
+    /// server-by-server and concatenating naively produces a shuffled parameter
+    /// vector. This function collects each server's buffer first, then walks the
+    /// `layer_offsets` table to copy each layer's slice into the output in the
+    /// correct order.
     ///
     /// # Args
     /// * `server_handles` - The handles for communicating with the servers.
+    /// * `layer_offsets` - Per-layer locations: `(server_id, start, end)` within
+    ///   each server's parameter buffer, indexed by layer index.
     /// * `user_event_tx` - The user sender for communicating if an error occurred.
     ///
     /// # Returns
-    /// The trained parameters of the model.
+    /// The trained parameters of the model in layer order.
     async fn finalize_parameter_server<T>(
         server_handles: Vec<ParamServerHandle<T>>,
+        layer_offsets: &[(usize, usize, usize)],
         user_event_tx: &Sender<TrainingEvent>,
     ) -> Vec<f32>
     where
         T: TransportLayer,
     {
-        // TODO: This implementation is wrong, the model layers aren't ordered
-        //       this way, the parameters are all shuffled up.
-
         debug!("all workers done, reading final params from all servers");
-        let mut model_params = Vec::new();
+        let nservers = server_handles.len();
+        let mut server_params: Vec<Option<Vec<f32>>> = vec![None; nservers];
 
         for (i, mut server_handle) in server_handles.into_iter().enumerate() {
             match server_handle.pull_params().await {
                 Ok(params) => {
-                    model_params.extend_from_slice(params);
+                    debug!("server {i}: pulled {} params", params.len());
+                    server_params[i] = Some(params.to_vec());
 
                     if let Err(e) = server_handle.disconnect().await {
                         error!("Failed to disconnect server {i}: {e}");
@@ -300,6 +312,16 @@ impl Session {
                     let event = TrainingEvent::Error(err);
                     let _ = user_event_tx.send(event).await;
                 }
+            }
+        }
+
+        let total: usize = layer_offsets.iter().map(|&(_, s, e)| e - s).sum();
+        let mut model_params = Vec::with_capacity(total);
+
+        for (layer_i, &(server_id, start, end)) in layer_offsets.iter().enumerate() {
+            if let Some(ref sp) = server_params[server_id] {
+                debug!("layer {layer_i}: server {server_id} [{start}..{end}]");
+                model_params.extend_from_slice(&sp[start..end]);
             }
         }
 


### PR DESCRIPTION
### Problema

Al entrenar con múltiples parameter servers, `balanced_partitions` distribuye las capas entre servidores por tamaño (asignación greedy de mayor a menor). Al finalizar el entrenamiento, `finalize_parameter_server` recolectaba los pesos concatenando el buffer de cada servidor en orden de servidor — produciendo un vector de capas desordenado (ej: capas [0, 2, 1, 3] en lugar de [0, 1, 2, 3]).

`save_safetensors` lee el buffer plano de parámetros secuencialmente por índice de capa, por lo que el modelo guardado tenía los pesos asignados a las capas incorrectas.

### Por qué los tests pasaban

Todos los modelos del benchmark usan redes densas con tamaños de capa monotónicamente decrecientes (784→128→64→10). Con esta forma, `balanced_partitions` asigna las capas a los servidores de manera tal que la concatenación en orden de servidor coincide casualmente con el orden correcto de capas. El bug sólo se manifiesta con tamaños de capa no monótonos o topologías específicas.

### Como lo arregle?

Mira el codigo gil