### PR TITLE
Fix early stopping never firing in ParameterServer mode

### DIFF
--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -150,7 +150,14 @@ impl Adapter {
         model: &ModelConfig,
         training: &TrainingConfig,
     ) -> Result<OrchAdapt> {
-        let Some(nworkers) = NonZeroUsize::new(training.addrs.len()) else {
+        let nworkers = match training.algorithm {
+            AlgorithmConfig::ParameterServer { nservers, .. } => {
+                training.addrs.len().saturating_sub(nservers.get())
+            }
+            _ => training.addrs.len(),
+        };
+
+        let Some(nworkers) = NonZeroUsize::new(nworkers) else {
             let text = "The amount of workers must be positive";
             return Err(OrchErr::InvalidConfig(text.into()));
         };


### PR DESCRIPTION
## Qué
Arregla que el **early stopping nunca se disparara en modo ParameterServer** (#170). Ahora frena correctamente cuando la mejora del loss cae por debajo de `early_stopping_tolerance`.

## Causa
`adapt_non_strategy_switch_orch` dimensionaba el `LossRecorder` con `addrs.len()` (workers **+ servers**). Como en un parameter server solo los workers publican losses, `LossRecorder::max()` —que exige `losses.len() == n`— nunca se llenaba, el `ConvergenceTracker` nunca se alimentaba y `StopReason::EarlyStopping` nunca se disparaba. `all_reduce` no estaba afectado porque ahí `addrs.len() == nworkers`.

## Cambio
Dimensionar el recorder por la cantidad real de workers: `addrs.len() - nservers` para ParameterServer, `addrs.len()` para AllReduce.

## Verificación
| caso | antes | ahora |
|---|---|---|
| PS tol=10.0 | corría 500/500 | frena en ep 3 |
| PS tol=1.0 | 500/500 | ep 3 |
| PS tol=0.01 | 500/500 | ep 30 |
| PS 2 servers tol=1.0 | 500/500 | ep 3 |
| PS sin early stopping (control) | — | corre completo (no frena de más) |
| AllReduce tol=1.0 (no-regresión) | ep 4 | ep 4 |

Closes #170
