### PR TITLE
Validate model layer dimensions against the dataset

### DIFF
--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -1060,10 +1060,8 @@ impl Adapter {
 
                 let layer_size = filters * channels * kernel_size * kernel_size + filters;
                 let input_dim = (input_dim.0.get(), input_dim.1.get(), input_dim.2.get());
-                let output_height = (input_dim.1 + 2 * padding - kernel_size) / stride + 1;
-                let output_width = (input_dim.2 + 2 * padding - kernel_size) / stride + 1;
-                let output_size = output_height * output_width * filters;
-                let sizes = (input_size.get(), layer_size, output_size);
+                let output_size = layer.output_size();
+                let sizes = (input_size.get(), layer_size, output_size.get());
 
                 (
                     LayerSpec::Conv {
@@ -1074,8 +1072,7 @@ impl Adapter {
                         act_fn: act_fn_spec,
                     },
                     self.adapt_param_gen(init, sizes),
-                    // SAFETY: input config has already been validated at this point.
-                    NonZeroUsize::new(output_size).unwrap(),
+                    output_size,
                 )
             }
         }

--- a/orchestrator/src/configs/model.rs
+++ b/orchestrator/src/configs/model.rs
@@ -51,6 +51,47 @@ pub enum LayerConfig {
     },
 }
 
+impl LayerConfig {
+    /// The amount of values this layer produces.
+    ///
+    /// # Returns
+    /// The layer's output size.
+    pub fn output_size(&self) -> NonZeroUsize {
+        match *self {
+            LayerConfig::Dense { output_size, .. } => output_size,
+            LayerConfig::Conv {
+                input_dim,
+                kernel_dim,
+                stride,
+                padding,
+                ..
+            } => {
+                let (filters, _, kernel_size) =
+                    (kernel_dim.0.get(), kernel_dim.1.get(), kernel_dim.2.get());
+                let output_height =
+                    (input_dim.1.get() + 2 * padding).saturating_sub(kernel_size) / stride.get() + 1;
+                let output_width =
+                    (input_dim.2.get() + 2 * padding).saturating_sub(kernel_size) / stride.get() + 1;
+
+                NonZeroUsize::new(output_height * output_width * filters).unwrap()
+            }
+        }
+    }
+
+    /// The flattened input size this layer expects, when it is fixed by the layer itself.
+    ///
+    /// # Returns
+    /// `Some(size)` for layers with a fixed input shape (`Conv`), `None` otherwise.
+    pub fn expected_input_size(&self) -> Option<NonZeroUsize> {
+        match *self {
+            LayerConfig::Conv { input_dim, .. } => {
+                NonZeroUsize::new(input_dim.0.get() * input_dim.1.get() * input_dim.2.get())
+            }
+            LayerConfig::Dense { .. } => None,
+        }
+    }
+}
+
 /// The `Model` configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/orchestrator/src/configs/validator.rs
+++ b/orchestrator/src/configs/validator.rs
@@ -28,6 +28,43 @@ impl Validator {
     pub fn validate(&self, model: &ModelConfig, training: &TrainingConfig) -> Result<()> {
         self.validate_model(model)?;
         self.validate_training(training)?;
+        self.validate_dimensions(model, training)?;
+        Ok(())
+    }
+
+    /// Validates that the model's layer dimensions are consistent with the dataset.
+    ///
+    /// # Args
+    /// * `model` - The model architecture and initialization configuration.
+    /// * `training` - The training configuration.
+    ///
+    /// # Errors
+    /// An `OrchErr` if a layer's expected input does not match the size it receives,
+    /// or if the model's output size does not match the dataset's `y_size`.
+    fn validate_dimensions(&self, model: &ModelConfig, training: &TrainingConfig) -> Result<()> {
+        let mut input_size = training.dataset.x_size;
+
+        for layer in &model.layers {
+            if let Some(expected) = layer.expected_input_size()
+                && expected != input_size
+            {
+                let text = format!(
+                    "layer expects an input of {expected} but the incoming size is {input_size}"
+                );
+                return Err(OrchErr::InvalidConfig(text));
+            }
+
+            input_size = layer.output_size();
+        }
+
+        if input_size != training.dataset.y_size {
+            let text = format!(
+                "the model's output size ({input_size}) must match the dataset's y_size ({})",
+                training.dataset.y_size
+            );
+            return Err(OrchErr::InvalidConfig(text));
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Qué
Valida las dimensiones del modelo contra el dataset **antes** de entrenar, en vez de dejar que un worker crashee con `early eof`.

## Cambio
- `LayerConfig::output_size()` y `expected_input_size()` (única fuente de verdad de dimensiones; `adapt_layer` ahora las usa en vez de la fórmula inline duplicada).
- `Validator::validate_dimensions()` recorre las capas desde `x_size` y chequea que cada capa con forma fija (Conv) reciba el tamaño correcto y que la salida final coincida con `y_size`. Si no → `InvalidConfig`.

## Verificación (ejecuciones)
- Última capa con `output_size != y_size` → `invalid config: the model's output size (N) must match the dataset's y_size`.
- Conv con canales/dims que no matchean → `invalid config: layer expects an input of N but the incoming size is M`.
- Modelo válido (dense y conv) → entrena OK (5 épocas).

Closes #174
