### PR TITLE
Reassemble strategy_switch params by server id

### DIFF
--- a/comms/src/handles/parameter_server.rs
+++ b/comms/src/handles/parameter_server.rs
@@ -39,6 +39,14 @@ where
         }
     }
 
+    /// The server's id.
+    ///
+    /// # Returns
+    /// The id number of the server.
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
     /// Enables the sparse gradient capability for this handle.
     ///
     /// # Args

--- a/comms/src/handles/worker.rs
+++ b/comms/src/handles/worker.rs
@@ -236,6 +236,7 @@ impl<T: TransportLayer> WorkerHandle<T> {
         spec: ServerSpec,
         ranges: Vec<(usize, usize)>,
     ) -> io::Result<()> {
+        self.id = spec.id;
         let msg = Msg::Control(Command::Upgrade { spec, ranges });
         self.transport.send(&msg).await
     }

--- a/orchestrator/src/sessions/session.rs
+++ b/orchestrator/src/sessions/session.rs
@@ -293,7 +293,7 @@ impl Session {
         T: TransportLayer,
     {
         debug!("all workers done, reading final params from all servers");
-        let mut server_params = Vec::with_capacity(server_handles.len());
+        let mut server_params = vec![Vec::new(); server_handles.len()];
 
         let req_err = async |i, e| {
             let details = format!("unexpected error from server {i}: {e}");
@@ -303,6 +303,7 @@ impl Session {
         };
 
         for (i, mut server_handle) in server_handles.into_iter().enumerate() {
+            let server_id = server_handle.id();
             // TODO: Acá eventualmente hay que ver como manejamos las caídas de
             //       los servidores. Capaz conviene tener a mano al Acceptor y
             //       en caso de que un servidor no responda que se vuelva a
@@ -321,7 +322,7 @@ impl Session {
                 match server_handle.pull_params().await {
                     Ok(params) => {
                         debug!("server {i}: pulled {} params", params.len());
-                        server_params.push(params.to_vec());
+                        server_params[server_id] = params.to_vec();
 
                         if let Err(e) = server_handle.disconnect().await {
                             error!("Failed to disconnect server {i}: {e}");


### PR DESCRIPTION
## Qué
Arregla el panic de finalización de `strategy_switch` con `nservers >= 2` (#175).

## Cambio
El handle de un server upgradeado se creaba con el id del **worker**, y `finalize_parameter_server` ubicaba los params en **orden de llegada** pero los indexaba por el id de partición del server. Con varios servers eso desalineaba y reventaba con un slice fuera de rango.

- `WorkerHandle` recuerda el id de partición (`ServerSpec.id`) al hacer `upgrade`, y `upgrade_handle` lo usa.
- `finalize_parameter_server` ubica los params de cada server **por su id**, no por orden de llegada.
- No-op para parameter_server normal (los handles ya están en orden).

## Verificación (ejecuciones)
- strategy_switch `nservers=2`: ya **no** panickea en finalize (era 0/6, determinístico → resuelto).
- Regresiones OK: strategy_switch `nservers=1` y parameter_server `nservers=2` entrenan bien.

Nota: queda una race intermitente aparte (post-switch, `IncompatibleShape` en el worker) que comparte el `unwrap` de #176 y se trackea ahí.

Closes #175
