### PR TITLE
Track convergence loss by the live worker count

### DIFF
--- a/orchestrator/src/configs/adapter.rs
+++ b/orchestrator/src/configs/adapter.rs
@@ -150,18 +150,6 @@ impl Adapter {
         model: &ModelConfig,
         training: &TrainingConfig,
     ) -> Result<OrchAdapt> {
-        let nworkers = match training.algorithm {
-            AlgorithmConfig::ParameterServer { nservers, .. } => {
-                training.addrs.len().saturating_sub(nservers.get())
-            }
-            _ => training.addrs.len(),
-        };
-
-        let Some(nworkers) = NonZeroUsize::new(nworkers) else {
-            let text = "The amount of workers must be positive";
-            return Err(OrchErr::InvalidConfig(text.into()));
-        };
-
         let convergence_tracker = training.early_stopping.map(|cfg| {
             let winsize = GreaterThanOneUsize::new(3).unwrap();
             ConvergenceTracker::new(winsize, cfg.tolerance)
@@ -176,7 +164,7 @@ impl Adapter {
 
         let adapt = OrchAdapt {
             input_size: training.dataset.x_size,
-            loss_recorder: LossRecorder::new(nworkers),
+            loss_recorder: LossRecorder::new(),
             convergence_tracker,
             switch_tracking: None,
             model_config: model.clone(),
@@ -207,11 +195,6 @@ impl Adapter {
         synchronizer: SynchronizerConfig,
         store: StoreConfig,
     ) -> Result<OrchAdapt> {
-        let Some(nentities) = NonZeroUsize::new(training.addrs.len()) else {
-            let text = "The amount of entities must be positive";
-            return Err(OrchErr::InvalidConfig(text.into()));
-        };
-
         let convergence_tracker = training.early_stopping.map(|cfg| {
             let winsize = GreaterThanOneUsize::new(3).unwrap();
             ConvergenceTracker::new(winsize, cfg.tolerance)
@@ -263,7 +246,7 @@ impl Adapter {
 
         let adapt = OrchAdapt {
             input_size: training.dataset.x_size,
-            loss_recorder: LossRecorder::new(nentities),
+            loss_recorder: LossRecorder::new(),
             convergence_tracker,
             switch_tracking: Some(tracking),
             model_config: model.clone(),

--- a/orchestrator/src/sessions/event_listener.rs
+++ b/orchestrator/src/sessions/event_listener.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{mem, num::NonZeroUsize};
 
 use comms::{NetRtp, ParamServerHandle};
 use log::info;
@@ -144,7 +144,11 @@ impl<'a> EventListener<'a> {
             self.loss_recorder.record(worker_id, last);
         }
 
-        let Some(loss) = self.loss_recorder.max() else {
+        let Some(workers) = NonZeroUsize::new(self.workers_left) else {
+            return;
+        };
+
+        let Some(loss) = self.loss_recorder.max(workers) else {
             return;
         };
 

--- a/orchestrator/src/sessions/loss_recorder.rs
+++ b/orchestrator/src/sessions/loss_recorder.rs
@@ -1,25 +1,18 @@
 use std::{collections::HashMap, num::NonZeroUsize};
 
 /// Records statistics of the worker losses.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LossRecorder {
     losses: HashMap<usize, f64>,
-    n: NonZeroUsize,
 }
 
 impl LossRecorder {
     /// Creates a new `LossRecorder`.
     ///
-    /// # Args
-    /// * `n` - The amount of worker losses to track simultaneously.
-    ///
     /// # Returns
     /// A new `LossRecorder` instance.
-    pub fn new(n: NonZeroUsize) -> Self {
-        Self {
-            losses: HashMap::with_capacity(n.get()),
-            n,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Records a new loss for a worker.
@@ -35,21 +28,27 @@ impl LossRecorder {
 
     /// Gets the max loss of all the workers.
     ///
+    /// # Args
+    /// * `workers` - The amount of workers currently expected to report.
+    ///
     /// # Returns
     /// Either `Some(loss)` or `None` if not all workers have recorded losses.
-    pub fn max(&self) -> Option<f64> {
-        self.check_full()?;
+    pub fn max(&self, workers: NonZeroUsize) -> Option<f64> {
+        self.check_full(workers)?;
         self.losses.values().copied().max_by(f64::total_cmp)
     }
 
     /// Gets the mean loss of all the workers.
     ///
+    /// # Args
+    /// * `workers` - The amount of workers currently expected to report.
+    ///
     /// # Returns
     /// Either `Some(loss)` or `None` if not all workers have recorded losses.
-    pub fn mean(&self) -> Option<f64> {
-        self.check_full()?;
+    pub fn mean(&self, workers: NonZeroUsize) -> Option<f64> {
+        self.check_full(workers)?;
         let sum: f64 = self.losses.values().sum();
-        Some(sum / self.n.get() as f64)
+        Some(sum / workers.get() as f64)
     }
 
     /// Clears the inner state for the following recording.
@@ -59,9 +58,12 @@ impl LossRecorder {
 
     /// Checks wheather the inner losses map is full or not.
     ///
+    /// # Args
+    /// * `workers` - The amount of workers currently expected to report.
+    ///
     /// # Returns
     /// `Some(())` if it is, `None` otherwise.
-    fn check_full(&self) -> Option<()> {
-        (self.losses.len() == self.n.get()).then_some(())
+    fn check_full(&self, workers: NonZeroUsize) -> Option<()> {
+        (self.losses.len() == workers.get()).then_some(())
     }
 }


### PR DESCRIPTION
## Qué
El early stopping no frenaba después de cambiar la cantidad de workers (#177) ni en parameter_server por contar mal (#170).

## Cambio
El `LossRecorder` ya no guarda la cantidad de workers; `max`/`mean` la reciben por parámetro, y `EventListener` le pasa el conteo vivo (`workers_left`, que se decrementa en `Upgraded`/`WorkerDone`). Así la agregación de loss se completa con la cantidad de workers vigente en cada momento.

## Verificación (ejecuciones, tolerancia alta → debe frenar enseguida)
- `strategy_switch` (1 server) + early stopping → frena en **ep 4/500** (antes corría hasta 500).
- `parameter_server` (1 server) + early stopping → frena en **ep 3/500** (#170).
- `parameter_server` sin early stopping → corre completo (no frena de más).

Reemplaza al PR #173 (que arreglaba solo el caso estático de parameter_server).

Closes #177
Closes #170
