### PR TITLE
Max pooling timeout + exposición de MaxPooling en la FFI

### DIFF
--- a/machine_learning/src/arch/layers/max_pooling.rs
+++ b/machine_learning/src/arch/layers/max_pooling.rs
@@ -125,6 +125,7 @@ impl MaxPooling {
 
     pub fn backward(&mut self, d_in: ArrayViewMut4<f32>) -> Result<ArrayViewMut4<'_, f32>> {
         let Self {
+            padding,
             real_input_dim,
             ref mut delta_out,
             ref max_indices,
@@ -137,8 +138,16 @@ impl MaxPooling {
 
         for b in 0..batches {
             for c in 0..in_channels {
-                azip!((d in &d_in, &idx in max_indices) {
-                    delta_out[[b,c,idx.0,idx.1]] = *d;
+                let d_bc = d_in.slice(s![b, c, .., ..]);
+                let max_indices_bc = max_indices.slice(s![b, c, .., ..]);
+                azip!((&d in &d_bc, &idx in &max_indices_bc) {
+                    if let (Some(row), Some(col)) =
+                        (idx.0.checked_sub(padding), idx.1.checked_sub(padding))
+                        && row < real_input_dim.0
+                        && col < real_input_dim.1
+                    {
+                        delta_out[[b, c, row, col]] = d;
+                    }
                 });
             }
         }
@@ -263,6 +272,79 @@ mod tests {
             [0., 6., 7., 8.],
             [0., 10., 11., 12.],
             [0., 14., 15., 16.]
+        ]]];
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_max_pooling_backward_routes_per_channel_independently() {
+        // 1 batch, 2 channels, 4x4, filter 2 stride 2.
+        // Each channel has its maxima in DIFFERENT positions so we can detect
+        // whether the backward pass routes each channel's delta independently.
+        let input = array![[
+            [
+                [1., 2., 3., 4.],
+                [5., 6., 7., 8.],
+                [9., 10., 11., 12.],
+                [13., 14., 15., 16.]
+            ],
+            [
+                [16., 15., 14., 13.],
+                [12., 11., 10., 9.],
+                [8., 7., 6., 5.],
+                [4., 3., 2., 1.]
+            ]
+        ]];
+        let mut max_pooling = MaxPooling::new(2, 2, 0);
+        max_pooling.forward(input.view()).unwrap();
+
+        // upstream delta: distinct per channel so mixing would be visible.
+        let mut delta_in = array![[
+            [[1., 2.], [3., 4.]],
+            [[10., 20.], [30., 40.]]
+        ]];
+
+        let output = max_pooling.backward(delta_in.view_mut()).unwrap();
+
+        // channel 0 maxima at (1,1),(1,3),(3,1),(3,3); channel 1 maxima at (0,0),(0,2),(2,0),(2,2)
+        let expected = array![[
+            [
+                [0., 0., 0., 0.],
+                [0., 1., 0., 2.],
+                [0., 0., 0., 0.],
+                [0., 3., 0., 4.]
+            ],
+            [
+                [10., 0., 20., 0.],
+                [0., 0., 0., 0.],
+                [30., 0., 40., 0.],
+                [0., 0., 0., 0.]
+            ]
+        ]];
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_max_pooling_backward_with_padding_maps_to_real_input() {
+        let input = array![[[
+            [1., 2., 3., 4.],
+            [5., 6., 7., 8.],
+            [9., 10., 11., 12.],
+            [13., 14., 15., 16.]
+        ]]];
+        let mut max_pooling = MaxPooling::new(2, 2, 1);
+        max_pooling.forward(input.view()).unwrap();
+
+        let mut delta_in = array![[[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]];
+
+        let output = max_pooling.backward(delta_in.view_mut()).unwrap();
+        let expected = array![[[
+            [1., 0., 2., 3.],
+            [0., 0., 0., 0.],
+            [4., 0., 5., 6.],
+            [7., 0., 8., 9.]
         ]]];
 
         assert_eq!(output, expected);

--- a/machine_learning/src/training/builder.rs
+++ b/machine_learning/src/training/builder.rs
@@ -221,7 +221,7 @@ impl TrainerBuilder {
                         stride,
                         padding,
                         ..
-                    } => self.spatial_size(input_dim, filter_size, stride, padding, input_dim.2),
+                    } => self.spatial_size(input_dim, filter_size, stride, padding, input_dim.0),
                     _ => unreachable!(),
                 };
                 layers.push(Layer::four_d_to2d(out_c, out_h, out_w))

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,7 +13,12 @@ use router::NodeRouter;
 const DEFAULT_HOST: &str = "0.0.0.0";
 
 /// The timeout duration for the reliable transport.
-const NETWORK_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// A worker trains a full epoch over its partition between messages, so for
+/// heavier models (conv/max pooling on MNIST) a peer can legitimately stay
+/// silent for far longer than a few seconds. The timeout must comfortably
+/// exceed the slowest per-epoch compute to avoid declaring a busy node dead.
+const NETWORK_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// The starting sleep duration for exponential backoff.
 const NETWORK_EXP_BACKOFF_BASE: Duration = Duration::from_secs(2);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,11 +13,6 @@ use router::NodeRouter;
 const DEFAULT_HOST: &str = "0.0.0.0";
 
 /// The timeout duration for the reliable transport.
-///
-/// A worker trains a full epoch over its partition between messages, so for
-/// heavier models (conv/max pooling on MNIST) a peer can legitimately stay
-/// silent for far longer than a few seconds. The timeout must comfortably
-/// exceed the slowest per-epoch compute to avoid declaring a busy node dead.
 const NETWORK_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// The starting sleep duration for exponential backoff.

--- a/orchestra-py/orchestra/arch.py
+++ b/orchestra-py/orchestra/arch.py
@@ -1,3 +1,3 @@
-from orchestra._orchestra import Conv2d, Dense
+from orchestra._orchestra import Conv2d, Dense, MaxPooling
 
-__all__ = ["Conv2d", "Dense"]
+__all__ = ["Conv2d", "Dense", "MaxPooling"]

--- a/orchestra-py/src/arch.rs
+++ b/orchestra-py/src/arch.rs
@@ -222,6 +222,73 @@ impl Conv2d {
     }
 }
 
+/// A 2D max pooling layer.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone)]
+pub struct MaxPooling {
+    pub input_dim: (NonZeroUsize, NonZeroUsize, NonZeroUsize),
+    pub filter_size: NonZeroUsize,
+    pub stride: NonZeroUsize,
+    pub padding: usize,
+    pub act_fn: Option<PyActFn>,
+}
+
+#[pymethods]
+impl MaxPooling {
+    /// Creates a MaxPooling layer configuration.
+    ///
+    /// # Args
+    /// * `input_dim` - Tuple `(in_channels, height, width)` of the input tensor.
+    /// * `filter_size` - Side of the square pooling window. Must be > 0.
+    /// * `stride` - Pooling stride. Must be > 0.
+    /// * `padding` - Zero-padding applied to each spatial side of the input.
+    /// * `act_fn` - Optional activation function (e.g. `Sigmoid()`). Defaults to `None`.
+    ///
+    /// # Returns
+    /// A MaxPooling layer configuration.
+    ///
+    /// # Errors
+    /// Raises a `ValueError` if any dimension, the filter size or the stride is zero.
+    /// Raises a `TypeError` if `act_fn` is not a supported type.
+    #[new]
+    #[pyo3(signature = (input_dim, filter_size, stride, padding, act_fn = None))]
+    pub fn new(
+        input_dim: (usize, usize, usize),
+        filter_size: usize,
+        stride: usize,
+        padding: usize,
+        act_fn: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Self> {
+        let make_nonzero = |v: usize, name: &'static str| {
+            NonZeroUsize::new(v).ok_or_else(|| PyValueError::new_err(format!("{name} must be > 0")))
+        };
+
+        Ok(Self {
+            input_dim: (
+                make_nonzero(input_dim.0, "input_dim.channels")?,
+                make_nonzero(input_dim.1, "input_dim.height")?,
+                make_nonzero(input_dim.2, "input_dim.width")?,
+            ),
+            filter_size: make_nonzero(filter_size, "filter_size")?,
+            stride: make_nonzero(stride, "stride")?,
+            padding,
+            act_fn: extract_act_fn(act_fn)?,
+        })
+    }
+}
+
+impl MaxPooling {
+    pub fn to_layer_config(&self) -> LayerConfig {
+        LayerConfig::MaxPooling {
+            input_dim: self.input_dim,
+            filter_size: self.filter_size,
+            stride: self.stride,
+            padding: self.padding,
+            act_fn: self.act_fn.as_ref().map(py_act_fn_to_config),
+        }
+    }
+}
+
 /// A sequential model — layers are applied in order.
 #[pyclass]
 pub struct Sequential {
@@ -233,14 +300,14 @@ impl Sequential {
     /// Creates a sequential model configuration.
     ///
     /// # Args
-    /// * `layers` - List of `Dense` or `Conv2d` layers. At least one required.
+    /// * `layers` - List of `Dense`, `Conv2d` or `MaxPooling` layers. At least one required.
     ///
     /// # Returns
     /// A sequential model configuration.
     ///
     /// # Errors
     /// Raises a `ValueError` if `layers` is empty.
-    /// Raises a `TypeError` if any element is not a `Dense` or `Conv2d` instance.
+    /// Raises a `TypeError` if any element is not a `Dense`, `Conv2d` or `MaxPooling` instance.
     #[new]
     pub fn new(layers: Vec<Bound<'_, PyAny>>) -> PyResult<Self> {
         if layers.is_empty() {
@@ -254,9 +321,11 @@ impl Sequential {
                     Ok(d.to_layer_config())
                 } else if let Ok(c) = l.extract::<PyRef<Conv2d>>() {
                     Ok(c.to_layer_config())
+                } else if let Ok(m) = l.extract::<PyRef<MaxPooling>>() {
+                    Ok(m.to_layer_config())
                 } else {
                     Err(PyTypeError::new_err(
-                        "each layer must be a Dense or Conv2d instance",
+                        "each layer must be a Dense, Conv2d or MaxPooling instance",
                     ))
                 }
             })

--- a/orchestra-py/src/lib.rs
+++ b/orchestra-py/src/lib.rs
@@ -18,6 +18,7 @@ fn _orchestra(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<arch::Sequential>()?;
     m.add_class::<arch::Dense>()?;
     m.add_class::<arch::Conv2d>()?;
+    m.add_class::<arch::MaxPooling>()?;
 
     m.add_class::<activations::Sigmoid>()?;
     m.add_class::<activations::Tanh>()?;


### PR DESCRIPTION
## Resumen

Sobre la rama de max pooling: arregla el **timeout de transporte** en MNIST, expone **MaxPooling en la FFI** y corrige un bug de gradientes en el backward de max pooling. MNIST pasa de **85% → 97.33%**.

## Timeout de transporte (causa raíz + fix)

El transporte confiable (`NetRtp = Retryer<TimeOuter<Framer>>`) usaba `NETWORK_TIMEOUT = 5s` por `recv`. Pero en el ciclo del worker de parameter server (`worker/src/workers/parameter_server.rs`), cada ronda llama a `trainer.train()`, que procesa **una epoch completa** sobre la partición del worker antes de hacer `push_grads()`.

Con modelos pesados (conv + max pooling sobre MNIST) una epoch tarda **mucho más que 5s** sin emitir mensajes, así que el peer que espera en `recv` dispara `TimedOut`, reintenta con backoff y termina **declarando muerto a un nodo que en realidad estaba computando**. (Por eso en el setup actual el MaxPooling estaba comentado y `max_epochs` bajado a 2.)

**Fix:** subir `NETWORK_TIMEOUT` a **120s** (`node/src/main.rs`), de modo que supere holgadamente el cómputo por epoch sin dejar de detectar nodos caídos.
> Nota: 120s cubre release con margen. Si se corre el orchestrator en **debug** (donde una epoch tarda varios minutos), conviene subirlo más o pasar a release.

## MaxPooling en la FFI

`MaxPooling(input_dim, filter_size, stride, padding, act_fn=None)` ya es construible desde Python igual que `Conv2d`/`Dense`:
- `orchestra-py/src/arch.rs`: nuevo `#[pyclass] MaxPooling` + `to_layer_config`, y aceptado en `Sequential`.
- `orchestra-py/src/lib.rs`: registrado en el módulo.
- `orchestra/arch.py`: re-exportado.

## Bonus: bug de gradientes en el backward de max pooling

El backward escribía el mismo gradiente mezclado en todos los planos `(batch, canal)` (el `azip` recorría todo el 4D pero el destino tomaba `b,c` del loop externo). Quedaba oculto porque todos los tests eran de 1 batch / 1 canal. Se rutea por plano `(b,c)` (como conv2d) y se mapean los índices del input efectivo restando el padding. Es lo que destraba el salto de accuracy.

## Validación
- Tests de max pooling: 10/10 (incluye 2 regresiones: ruteo por canal y padding).
- Test de convergencia conv+maxpool de 2 canales: OK.
- MNIST local (Nielsen, 60 epochs): **97.33%**.
- FFI: build con maturin OK + smoke test desde Python OK.