### PR TITLE
Loss/epoch overlap and real-rate data-flow animation

### DIFF
--- a/orchestui/src/main.rs
+++ b/orchestui/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod config;
+mod naming;
 mod ui;
 
 use anyhow::Result;

--- a/orchestui/src/naming.rs
+++ b/orchestui/src/naming.rs
@@ -1,0 +1,50 @@
+//! Random, playful file names for auto-saved models, e.g. `nice_gradient`.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Short, friendly adjectives.
+const ADJECTIVES: [&str; 50] = [
+    "nice", "cute", "super", "tiny", "mega", "bold", "calm", "cool", "warm", "wild", "fuzzy",
+    "shiny", "silky", "brave", "chill", "crisp", "dizzy", "eager", "fancy", "giant", "happy",
+    "jolly", "lucky", "merry", "noble", "plush", "quick", "rapid", "sassy", "snug", "spicy",
+    "swift", "witty", "zesty", "bouncy", "breezy", "cheery", "cosmic", "dreamy", "gentle", "glowy",
+    "groovy", "jazzy", "lively", "mighty", "peppy", "quirky", "sleepy", "sneaky", "sunny",
+];
+
+/// Deep-learning / ML flavored terms.
+const TERMS: [&str; 50] = [
+    "transformer", "hopfield", "gradient", "backprop", "tensor", "neuron", "softmax", "sigmoid",
+    "relu", "dropout", "epoch", "weight", "bias", "kernel", "embedding", "attention", "encoder",
+    "decoder", "perceptron", "convolution", "pooling", "adam", "sgd", "momentum", "entropy",
+    "logit", "activation", "batchnorm", "layernorm", "autograd", "manifold", "eigenvector",
+    "jacobian", "hessian", "optimizer", "regressor", "classifier", "boltzmann", "autoencoder",
+    "lstm", "gru", "resnet", "bert", "gan", "diffusion", "latent", "feature", "sampler", "learner",
+    "network",
+];
+
+/// Returns a random `<adjective>_<term>.safetensors` file name.
+///
+/// The two words are drawn from a time-seeded xorshift, so no extra dependency
+/// is needed just to pick a name.
+pub fn random_model_name() -> String {
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x9E37_79B9_7F4A_7C15);
+
+    let mut x = seed | 1;
+    let adjective = ADJECTIVES[(next(&mut x) as usize) % ADJECTIVES.len()];
+    let term = TERMS[(next(&mut x) as usize) % TERMS.len()];
+
+    format!("{adjective}_{term}.safetensors")
+}
+
+/// Advances an xorshift64 state and returns the new value.
+fn next(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}

--- a/orchestui/src/ui/components/confirm_quit.rs
+++ b/orchestui/src/ui/components/confirm_quit.rs
@@ -9,18 +9,26 @@ use ratatui::{
 use crate::ui::{theme::Theme, utils::centered_rect_fixed};
 
 /// Draws the quit confirmation popup centered over the current screen.
-pub fn draw_confirm_quit(f: &mut Frame) {
+///
+/// `finished` tailors the message: once training is done the model is already
+/// saved, so leaving only means returning to the menu.
+pub fn draw_confirm_quit(f: &mut Frame, finished: bool) {
     let area = centered_rect_fixed(44, 5, f.size());
     f.render_widget(Clear, area);
+    let (headline, stay) = if finished {
+        ("Training finished — model saved.", " stay here")
+    } else {
+        ("Training is still running.", " keep training")
+    };
     f.render_widget(
         Paragraph::new(vec![
-            Line::from(Span::styled("Training is still running.", Theme::warn())),
+            Line::from(Span::styled(headline, Theme::warn())),
             Line::from(Span::raw("")),
             Line::from(vec![
                 Span::styled("[y]", Theme::ok()),
                 Span::styled(" back to menu      ", Theme::text()),
                 Span::styled("[n]", Theme::error()),
-                Span::styled(" keep training", Theme::text()),
+                Span::styled(stay, Theme::text()),
             ]),
         ])
         .block(

--- a/orchestui/src/ui/components/topology.rs
+++ b/orchestui/src/ui/components/topology.rs
@@ -40,13 +40,11 @@ const COLOR_DONE: Color = Color::Rgb(40, 140, 255);
 const COLOR_SERVER: Color = Color::Rgb(0, 210, 210);
 const COLOR_CONN: Color = Color::Rgb(0, 55, 0);
 const COLOR_PARTICLE: Color = Color::Rgb(255, 200, 0);
-const ANIM_PERIOD_MS: u128 = 1800;
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 pub fn draw_topology(f: &mut Frame, area: ratatui::layout::Rect, state: &TrainingState) {
     let (nodes, conns, radius) = compute_layout(state);
-    let elapsed_ms = state.started_at.elapsed().as_millis();
     let is_active = state.is_active();
     let phase = state.phase;
 
@@ -63,7 +61,7 @@ pub fn draw_topology(f: &mut Frame, area: ratatui::layout::Rect, state: &Trainin
         .x_bounds([0.0, 200.0])
         .y_bounds([0.0, 100.0])
         .paint(|ctx| {
-            draw_connections(ctx, &nodes, &conns, elapsed_ms, is_active, phase);
+            draw_connections(ctx, &nodes, &conns, state.flow_phase, is_active, phase);
             draw_shapes(ctx, state, &nodes, phase, radius);
             draw_node_content(ctx, state, &nodes, phase, radius, row);
             draw_static_labels(ctx, state, &nodes, radius);
@@ -305,7 +303,7 @@ fn draw_connections(
     ctx: &mut Context,
     nodes: &[NodeInfo],
     conns: &[Connection],
-    elapsed_ms: u128,
+    flow_phase: f64,
     is_active: bool,
     phase: Phase,
 ) {
@@ -329,8 +327,8 @@ fn draw_connections(
     for (ci, conn) in conns.iter().enumerate() {
         let a = &nodes[conn.from_idx];
         let b = &nodes[conn.to_idx];
-        let offset = (ci as u128 * ANIM_PERIOD_MS) / n as u128;
-        let t = ((elapsed_ms + offset) % ANIM_PERIOD_MS) as f64 / ANIM_PERIOD_MS as f64;
+        // Stagger each wire's particle so the flow reads as a continuous stream.
+        let t = (flow_phase + ci as f64 / n as f64).fract();
         let pr = (1.5_f64).min(0.18 * radius_estimate(a, b));
         ctx.draw(&Circle {
             x: a.x + t * (b.x - a.x),

--- a/orchestui/src/ui/components/topology.rs
+++ b/orchestui/src/ui/components/topology.rs
@@ -50,10 +50,12 @@ pub fn draw_topology(f: &mut Frame, area: ratatui::layout::Rect, state: &Trainin
     let is_active = state.is_active();
     let phase = state.phase;
 
-    // Canvas units per text row: lets us space the node's inner lines exactly
-    // one row apart regardless of terminal height.
+    // Canvas units per text row. Ratatui maps labels with a `height - 1`
+    // resolution, so the divisor must match to keep each node line exactly one
+    // terminal row apart; otherwise adjacent lines round onto the same row and
+    // the loss overlaps the epoch counter.
     let inner_h = area.height.saturating_sub(2).max(1) as f64;
-    let row = 100.0 / inner_h;
+    let row = 100.0 / (inner_h - 1.0).max(1.0);
 
     let canvas = Canvas::default()
         .block(topology_block(state))

--- a/orchestui/src/ui/components/topology.rs
+++ b/orchestui/src/ui/components/topology.rs
@@ -45,7 +45,6 @@ const COLOR_PARTICLE: Color = Color::Rgb(255, 200, 0);
 
 pub fn draw_topology(f: &mut Frame, area: ratatui::layout::Rect, state: &TrainingState) {
     let (nodes, conns, radius) = compute_layout(state);
-    let is_active = state.is_active();
     let phase = state.phase;
 
     // Canvas units per text row. Ratatui maps labels with a `height - 1`
@@ -61,7 +60,7 @@ pub fn draw_topology(f: &mut Frame, area: ratatui::layout::Rect, state: &Trainin
         .x_bounds([0.0, 200.0])
         .y_bounds([0.0, 100.0])
         .paint(|ctx| {
-            draw_connections(ctx, &nodes, &conns, state.flow_phase, is_active, phase);
+            draw_connections(ctx, &nodes, &conns, state.flow_phase, phase);
             draw_shapes(ctx, state, &nodes, phase, radius);
             draw_node_content(ctx, state, &nodes, phase, radius, row);
             draw_static_labels(ctx, state, &nodes, radius);
@@ -304,7 +303,6 @@ fn draw_connections(
     nodes: &[NodeInfo],
     conns: &[Connection],
     flow_phase: f64,
-    is_active: bool,
     phase: Phase,
 ) {
     for conn in conns {
@@ -319,7 +317,9 @@ fn draw_connections(
         });
     }
 
-    if !is_active || phase == Phase::Finished || phase == Phase::Error {
+    // Particles only flow once real data does: no movement until the first loss
+    // report flips the phase to Training (before that every node is connecting).
+    if phase != Phase::Training {
         return;
     }
 

--- a/orchestui/src/ui/screens/training.rs
+++ b/orchestui/src/ui/screens/training.rs
@@ -26,6 +26,18 @@ use crate::ui::{
     utils::fmt_loss,
 };
 
+/// Fastest particle traversal, so bursts of quick reports stay watchable.
+const FLOW_PERIOD_MIN_MS: f64 = 500.0;
+/// Slowest particle traversal, and the initial speed before any measurement:
+/// slow enough to read as "warming up", but still visibly moving.
+const FLOW_PERIOD_MAX_MS: f64 = 10_000.0;
+/// The flow tracks the real per-epoch interval compressed by this factor, so it
+/// stays watchable when epochs are tens of seconds apart while remaining
+/// proportional to the true reporting speed.
+const FLOW_SPEEDUP: f64 = 6.0;
+/// Weight of the newest sample in the smoothed per-epoch interval (EMA).
+const FLOW_SMOOTHING: f64 = 0.3;
+
 /// Per-worker colors for charts and table highlights.
 pub const WORKER_COLORS: &[Color] = &[
     Color::Rgb(57, 255, 20),
@@ -135,6 +147,17 @@ pub struct TrainingState {
     pub max_epochs: usize,
     pub phase: Phase,
     pub started_at: Instant,
+    /// Normalized [0, 1) position of the data-flow particles, advanced every
+    /// frame at a rate derived from how fast workers actually report losses.
+    pub flow_phase: f64,
+    /// Wall-clock of the previous frame, used to advance `flow_phase` by the
+    /// real elapsed time regardless of the render cadence.
+    last_frame_at: Instant,
+    /// Wall-clock of the most recent loss report, used to measure the interval
+    /// between reports.
+    last_loss_at: Option<Instant>,
+    /// Smoothed real interval between per-epoch loss reports, in milliseconds.
+    loss_interval_ms: Option<f64>,
     pub workers: Vec<WorkerState>,
     /// Per-worker loss time series as (epoch, loss) pairs.
     pub loss_series: Vec<Vec<(f64, f64)>>,
@@ -249,6 +272,10 @@ impl TrainingState {
             max_epochs,
             phase: initial_phase,
             started_at: Instant::now(),
+            flow_phase: 0.0,
+            last_frame_at: Instant::now(),
+            last_loss_at: None,
+            loss_interval_ms: None,
             workers,
             loss_series,
             logs: vec![(LogLevel::Info, initial_log)],
@@ -314,6 +341,50 @@ impl TrainingState {
         for event in events {
             self.apply(event);
         }
+
+        self.advance_flow();
+    }
+
+    /// Advances the data-flow animation by the real time elapsed since the last
+    /// frame, at a rate proportional to how fast workers report losses.
+    fn advance_flow(&mut self) {
+        let now = Instant::now();
+        let dt_ms = now.duration_since(self.last_frame_at).as_secs_f64() * 1000.0;
+        self.last_frame_at = now;
+        self.flow_phase = (self.flow_phase + dt_ms / self.flow_period_ms()).fract();
+    }
+
+    /// Records the arrival of a loss report, updating the smoothed per-epoch
+    /// interval that drives the flow animation speed.
+    fn record_loss_rate(&mut self, epochs: usize) {
+        let now = Instant::now();
+        if let Some(prev) = self.last_loss_at {
+            let per_epoch =
+                now.duration_since(prev).as_secs_f64() * 1000.0 / epochs.max(1) as f64;
+            // Blend from the current interval — seeded at the slow-start value — so
+            // the flow accelerates progressively toward the measured rate instead
+            // of snapping to it on the first report.
+            let current = self
+                .loss_interval_ms
+                .unwrap_or(FLOW_PERIOD_MAX_MS * FLOW_SPEEDUP);
+            self.loss_interval_ms =
+                Some(current * (1.0 - FLOW_SMOOTHING) + per_epoch * FLOW_SMOOTHING);
+        }
+        self.last_loss_at = Some(now);
+    }
+
+    /// Milliseconds for one full particle traversal of a connection.
+    ///
+    /// Tracks the real per-epoch reporting interval, compressed by `FLOW_SPEEDUP`
+    /// so it stays legible when epochs are slow, and clamped to a watchable range.
+    /// Before any measurement it starts slow and speeds up as reports arrive.
+    fn flow_period_ms(&self) -> f64 {
+        match self.loss_interval_ms {
+            Some(interval) => {
+                (interval / FLOW_SPEEDUP).clamp(FLOW_PERIOD_MIN_MS, FLOW_PERIOD_MAX_MS)
+            }
+            None => FLOW_PERIOD_MAX_MS,
+        }
     }
 
     /// Applies a single training event to the state.
@@ -321,6 +392,7 @@ impl TrainingState {
         match event {
             TrainingEvent::PublishedLosses { worker_id, losses } => {
                 self.phase = Phase::Training;
+                self.record_loss_rate(losses.len());
 
                 if worker_id < self.workers.len() {
                     for loss in &losses {

--- a/orchestui/src/ui/screens/training.rs
+++ b/orchestui/src/ui/screens/training.rs
@@ -25,6 +25,7 @@ use crate::ui::{
     theme::Theme,
     utils::fmt_loss,
 };
+use crate::naming::random_model_name;
 
 /// Fastest particle traversal, so bursts of quick reports stay watchable.
 const FLOW_PERIOD_MIN_MS: f64 = 500.0;
@@ -462,6 +463,7 @@ impl TrainingState {
                     ),
                 );
                 self.final_trained = Some(trained);
+                self.auto_save();
             }
             TrainingEvent::Error(e) => {
                 self.phase = Phase::Error;
@@ -470,6 +472,23 @@ impl TrainingState {
                 self.push_log(LogLevel::Error, msg);
             }
             _ => unreachable!(),
+        }
+    }
+
+    /// Auto-saves the finished model to `safetensors/<random-name>.safetensors`
+    /// and logs the resolved path (or the failure).
+    fn auto_save(&mut self) {
+        let Some(trained) = self.final_trained.as_ref() else {
+            return;
+        };
+        let dir = "safetensors";
+        let path = format!("{dir}/{}", random_model_name());
+        let outcome = std::fs::create_dir_all(dir)
+            .map_err(|e| e.to_string())
+            .and_then(|()| trained.save_safetensors(&path).map_err(|e| e.to_string()));
+        match outcome {
+            Ok(()) => self.push_log(LogLevel::Info, format!("model saved to {path}")),
+            Err(e) => self.push_log(LogLevel::Error, format!("failed to save model: {e}")),
         }
     }
 
@@ -674,6 +693,12 @@ pub fn handle_key(state: &mut TrainingState, key: KeyCode) -> Option<Action> {
             state.confirm_quit = ConfirmQuit::Hidden;
             None
         }
+        (KeyCode::Char('q') | KeyCode::Esc, ConfirmQuit::Hidden, false)
+            if state.phase == Phase::Finished =>
+        {
+            state.confirm_quit = ConfirmQuit::Visible;
+            None
+        }
         (KeyCode::Char('q') | KeyCode::Esc, ConfirmQuit::Hidden, false) => {
             Some(Action::Transition(Box::new(Screen::Menu(MenuState::new()))))
         }
@@ -746,7 +771,7 @@ pub fn draw(f: &mut Frame, state: &mut TrainingState) {
     }
 
     if state.confirm_quit == ConfirmQuit::Visible {
-        draw_confirm_quit(f);
+        draw_confirm_quit(f, state.phase == Phase::Finished);
     }
 
     if state.confirm_stop == ConfirmStop::Visible {


### PR DESCRIPTION
## Qué resuelve

Cierra la issue #197: dos problemas en la vista **Topology** de orchestui.

- **Loss/epoch pisados ("0.3/N")**: el espaciado de filas usaba `100/inner_h`, pero ratatui mapea los labels con resolución `height - 1`. Ese off-by-one hacía que, en algún nodo, la loss y el epoch cayeran en la misma fila y se pisaran. Ahora el divisor coincide y cada línea queda en su fila.
- **Velocidad del flujo proporcional al ritmo real**: las partículas dejan de usar un período fijo; se mueven según el intervalo real entre reportes de loss (suavizado por EMA), comprimido para seguir siendo visible aunque los epochs sean lentos. Arranca lento y acelera de forma progresiva.
- **Arranque honesto**: el flujo queda quieto mientras conecta y nace recién con el primer epoch (cuando hay data real).

## Guardado del modelo (orchestui)

Además, cambia cómo se guardan los `.safetensors` en la TUI:

- **Auto-guardado**: al terminar un entrenamiento el modelo se guarda solo en `safetensors/<nombre>.safetensors`; ya no hay que tocar `s` ni elegir un path. El path queda logueado en el panel de eventos.
- **Nombre aleatorio y gracioso**: se arma combinando al azar 50 adjetivos (nice, cute, super, …) con 50 términos de deep learning (transformer, hopfield, gradient, backprop, …), tipo `nice_gradient.safetensors`. Sin dependencias nuevas (semilla por tiempo + xorshift).
- **Confirmación al salir con el run terminado**: antes solo preguntaba "¿estás seguro?" mientras entrenaba; ahora también pregunta al volver al menú con un entrenamiento ya finalizado.

Esto aplica solo a orchestui; la FFI (`orchestra-py`) mantiene su `save_safetensors` manual.

Closes #197
