### PR TITLE
Cancel superseded CI runs on new pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Hoy cada push a una PR dispara un run nuevo sin cancelar el anterior, así que quedan varios corriendo en paralelo sobre commits que ya quedaron viejos y se consumen minutos de Actions de más.

Se agrega un grupo de concurrencia por workflow y rama: un push nuevo cancela el run anterior de esa misma PR.

Ramas distintas no se afectan entre sí. No cambia el nombre del job (`test`), que es el check requerido para mergear a main.
