### PR TITLE
fix: fixed the prints during a training session

### DIFF
--- a/orchestra-py/src/session.rs
+++ b/orchestra-py/src/session.rs
@@ -1,6 +1,5 @@
 use std::{
     io::{self, IsTerminal, Write},
-    mem,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -287,7 +286,7 @@ impl Session {
                         }
                     };
 
-                    let loss_history = mem::take(&mut reporter.loss_history);
+                    let loss_history = reporter.loss_history.clone();
                     reporter.finish(result.is_ok());
                     result.map(|trained| (trained, loss_history))
                 })


### PR DESCRIPTION
No se imprimian bien porque el `finish` espera hacer un `if let Some(last) = loss_history.last() { ... }`, cosa que esta vacia porque antes se le hace un `mem::take`, entonces `finish` no hace nada. Se puede hacer sin un clone pero sinceramente no lo amerita