### PR TITLE
Keep TUI logs out of the rendered frame

### DIFF
--- a/orchestui/src/main.rs
+++ b/orchestui/src/main.rs
@@ -3,17 +3,39 @@ mod config;
 mod naming;
 mod ui;
 
+use std::{
+    env,
+    fs::File,
+    io::{self, IsTerminal},
+    sync::Mutex,
+};
+
 use anyhow::Result;
 use tracing_subscriber::{fmt, EnvFilter};
 
-/// Initializes stderr logging, defaulting to `info` when `RUST_LOG` is unset.
+const LOG_FILE: &str = "ono-orchestui.log";
+
+/// Initializes logging, defaulting to `info` when `RUST_LOG` is unset.
+///
+/// Logs go to `LOG_FILE` in the temp directory when stderr is a terminal, since the TUI renders
+/// there and inline log lines would corrupt the frame. Otherwise they go to stderr.
 fn init_logging() {
-    fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .with_writer(std::io::stderr)
-        .init();
+    let builder = fmt().with_env_filter(
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    );
+
+    let log_file = io::stderr()
+        .is_terminal()
+        .then(|| File::create(env::temp_dir().join(LOG_FILE)).ok())
+        .flatten();
+
+    match log_file {
+        Some(file) => builder
+            .with_ansi(false)
+            .with_writer(Mutex::new(file))
+            .init(),
+        None => builder.with_writer(io::stderr).init(),
+    }
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
`orchestui` inicializaba tracing sobre stderr con nivel `info` por defecto. Como la TUI dibuja en esa misma terminal, las líneas de log se metían en el frame y rompían el render.

Ahora, cuando stderr es una terminal, los logs van a `ono-orchestui.log` en el directorio temporal. Si stderr está redirigido, se mantiene el comportamiento anterior, así que `orchestui/run.sh` sigue funcionando igual.

Sin dependencias nuevas: `IsTerminal` es de la librería estándar.
